### PR TITLE
[BD-14] [SE-3241] Scaffold and create initial unit tests with helpers.

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,3 +1,8 @@
 const { createConfig } = require('@edx/frontend-build');
 
-module.exports = createConfig('eslint');
+const combined = createConfig('eslint', {});
+
+// This is already defined upstream, so we need to modify it. The merge functionality provided by createConfig
+// doesn't handle it correctly.
+combined.rules["import/no-extraneous-dependencies"][1].devDependencies.push("**/specs/**");
+module.exports = combined;

--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,9 @@ tx_url2 = https://www.transifex.com/api/2/project/edx-platform/resource/$(transi
 # This directory must match .babelrc .
 transifex_temp = ./temp/babel-plugin-react-intl
 
+test:
+	npm run test
+
 precommit:
 	npm run lint
 	npm audit

--- a/README.rst
+++ b/README.rst
@@ -82,3 +82,6 @@ Known Issues
   libraries but cannot be edited using Studio's authoring view.  This is a
   limitation of Studio, not this MFE.  Work is under way to improve Studio
   accordingly.
+
+* Users with view only access are able to see the 'User Access' menu item, despite
+  the fact it will just kick them back to the detail view.

--- a/README.rst
+++ b/README.rst
@@ -64,11 +64,13 @@ Please see `edx/frontend-platform's i18n module <https://edx.github.io/frontend-
 Known Issues
 ------------
 
-* This MFE is missing unit tests.
-
 * This MFE requires a copy review.
 
 * This MFE requires an accessibility audit.
+
+* There are a handful of non-fatal errors that appear when running tests.
+  They appear to be related to the Modal component from Paragon not being up to
+  date with the version of React in this repository.
 
 * The styling in the account dropdown menu in the header does not currently
   match Studio's very well.  This will be improved shortly.

--- a/jest.config.js
+++ b/jest.config.js
@@ -4,8 +4,20 @@ module.exports = createConfig('jest', {
   setupFiles: [
     '<rootDir>/src/setupTest.js',
   ],
+  collectCoverageFrom: [
+    "**/*.{js,jsx}",
+  ],
+  testMatch: [
+    '**/specs/**/*.spec.(js|jsx)|**/__tests__/*.(js|jsx)',
+  ],
+  roots: [
+    '<rootDir>src/',
+  ],
   coveragePathIgnorePatterns: [
     'src/setupTest.js',
+    'jest.config.js',
     'src/i18n',
+    '/node_modules/',
+    '/specs/'
   ],
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -1189,6 +1189,12 @@
         "@babel/types": "^7.7.4"
       }
     },
+    "@babel/helper-validator-identifier": {
+      "version": "7.10.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.10.4.tgz",
+      "integrity": "sha512-3U9y+43hz7ZM+rzG24Qe2mufW5KhvFg/NhnNph+i9mgCtdTCtMJuI1TMkrIUiK7Ix4PYlRF9I5dhqaLYA/ADXw==",
+      "dev": true
+    },
     "@babel/helper-wrap-function": {
       "version": "7.8.3",
       "resolved": "https://registry.npmjs.org/@babel/helper-wrap-function/-/helper-wrap-function-7.8.3.tgz",
@@ -1495,6 +1501,40 @@
         }
       }
     },
+    "@babel/plugin-syntax-bigint": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-bigint/-/plugin-syntax-bigint-7.8.3.tgz",
+      "integrity": "sha512-wnTnFlG+YxQm3vDxpGE57Pj0srRU4sHE/mDkt1qv2YJJSeUAec2ma4WLUnUPeKjyrfntVwe/N6dCXpU+zL3Npg==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.8.0"
+      },
+      "dependencies": {
+        "@babel/helper-plugin-utils": {
+          "version": "7.10.4",
+          "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.10.4.tgz",
+          "integrity": "sha512-O4KCvQA6lLiMU9l2eawBPMf1xPP8xPfB3iEQw150hOVTqj/rfXz0ThTb4HEzqQfs2Bmo5Ay8BzxfzVtBrr9dVg==",
+          "dev": true
+        }
+      }
+    },
+    "@babel/plugin-syntax-class-properties": {
+      "version": "7.10.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-class-properties/-/plugin-syntax-class-properties-7.10.4.tgz",
+      "integrity": "sha512-GCSBF7iUle6rNugfURwNmCGG3Z/2+opxAMLs1nND4bhEG5PuxTIggDBoeYYSujAlLtsupzOHYJQgPS3pivwXIA==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.10.4"
+      },
+      "dependencies": {
+        "@babel/helper-plugin-utils": {
+          "version": "7.10.4",
+          "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.10.4.tgz",
+          "integrity": "sha512-O4KCvQA6lLiMU9l2eawBPMf1xPP8xPfB3iEQw150hOVTqj/rfXz0ThTb4HEzqQfs2Bmo5Ay8BzxfzVtBrr9dVg==",
+          "dev": true
+        }
+      }
+    },
     "@babel/plugin-syntax-dynamic-import": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-dynamic-import/-/plugin-syntax-dynamic-import-7.2.0.tgz",
@@ -1502,6 +1542,23 @@
       "dev": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.0.0"
+      }
+    },
+    "@babel/plugin-syntax-import-meta": {
+      "version": "7.10.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-meta/-/plugin-syntax-import-meta-7.10.4.tgz",
+      "integrity": "sha512-Yqfm+XDx0+Prh3VSeEQCPU81yC+JWZ2pDPFSS4ZdpfZhp4MkFMaDC1UqseovEKwSUpnIL7+vK+Clp7bfh0iD7g==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.10.4"
+      },
+      "dependencies": {
+        "@babel/helper-plugin-utils": {
+          "version": "7.10.4",
+          "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.10.4.tgz",
+          "integrity": "sha512-O4KCvQA6lLiMU9l2eawBPMf1xPP8xPfB3iEQw150hOVTqj/rfXz0ThTb4HEzqQfs2Bmo5Ay8BzxfzVtBrr9dVg==",
+          "dev": true
+        }
       }
     },
     "@babel/plugin-syntax-json-strings": {
@@ -1538,6 +1595,57 @@
         }
       }
     },
+    "@babel/plugin-syntax-logical-assignment-operators": {
+      "version": "7.10.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-logical-assignment-operators/-/plugin-syntax-logical-assignment-operators-7.10.4.tgz",
+      "integrity": "sha512-d8waShlpFDinQ5MtvGU9xDAOzKH47+FFoney2baFIoMr952hKOLp1HR7VszoZvOsV/4+RRszNY7D17ba0te0ig==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.10.4"
+      },
+      "dependencies": {
+        "@babel/helper-plugin-utils": {
+          "version": "7.10.4",
+          "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.10.4.tgz",
+          "integrity": "sha512-O4KCvQA6lLiMU9l2eawBPMf1xPP8xPfB3iEQw150hOVTqj/rfXz0ThTb4HEzqQfs2Bmo5Ay8BzxfzVtBrr9dVg==",
+          "dev": true
+        }
+      }
+    },
+    "@babel/plugin-syntax-nullish-coalescing-operator": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-nullish-coalescing-operator/-/plugin-syntax-nullish-coalescing-operator-7.8.3.tgz",
+      "integrity": "sha512-aSff4zPII1u2QD7y+F8oDsz19ew4IGEJg9SVW+bqwpwtfFleiQDMdzA/R+UlWDzfnHFCxxleFT0PMIrR36XLNQ==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.8.0"
+      },
+      "dependencies": {
+        "@babel/helper-plugin-utils": {
+          "version": "7.10.4",
+          "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.10.4.tgz",
+          "integrity": "sha512-O4KCvQA6lLiMU9l2eawBPMf1xPP8xPfB3iEQw150hOVTqj/rfXz0ThTb4HEzqQfs2Bmo5Ay8BzxfzVtBrr9dVg==",
+          "dev": true
+        }
+      }
+    },
+    "@babel/plugin-syntax-numeric-separator": {
+      "version": "7.10.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-numeric-separator/-/plugin-syntax-numeric-separator-7.10.4.tgz",
+      "integrity": "sha512-9H6YdfkcK/uOnY/K7/aA2xpzaAgkQn37yzWUMRK7OaPOqOpGS1+n0H5hxT9AUw9EsSjPW8SVyMJwYRtWs3X3ug==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.10.4"
+      },
+      "dependencies": {
+        "@babel/helper-plugin-utils": {
+          "version": "7.10.4",
+          "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.10.4.tgz",
+          "integrity": "sha512-O4KCvQA6lLiMU9l2eawBPMf1xPP8xPfB3iEQw150hOVTqj/rfXz0ThTb4HEzqQfs2Bmo5Ay8BzxfzVtBrr9dVg==",
+          "dev": true
+        }
+      }
+    },
     "@babel/plugin-syntax-object-rest-spread": {
       "version": "7.7.4",
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-object-rest-spread/-/plugin-syntax-object-rest-spread-7.7.4.tgz",
@@ -1560,6 +1668,23 @@
           "version": "7.8.3",
           "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.8.3.tgz",
           "integrity": "sha512-j+fq49Xds2smCUNYmEHF9kGNkhbet6yVIBp4e6oeQpH1RUs/Ir06xUKzDjDkGcaaokPiTNs2JBWHjaE4csUkZQ==",
+          "dev": true
+        }
+      }
+    },
+    "@babel/plugin-syntax-optional-chaining": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-optional-chaining/-/plugin-syntax-optional-chaining-7.8.3.tgz",
+      "integrity": "sha512-KoK9ErH1MBlCPxV0VANkXW2/dw4vlbGDrFgz8bmUsBGYkFRcbRwMh6cIJubdPrkxRwuGdtCk0v/wPTKbQgBjkg==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.8.0"
+      },
+      "dependencies": {
+        "@babel/helper-plugin-utils": {
+          "version": "7.10.4",
+          "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.10.4.tgz",
+          "integrity": "sha512-O4KCvQA6lLiMU9l2eawBPMf1xPP8xPfB3iEQw150hOVTqj/rfXz0ThTb4HEzqQfs2Bmo5Ay8BzxfzVtBrr9dVg==",
           "dev": true
         }
       }
@@ -2444,6 +2569,24 @@
         }
       }
     },
+    "@babel/runtime-corejs3": {
+      "version": "7.11.2",
+      "resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.11.2.tgz",
+      "integrity": "sha512-qh5IR+8VgFz83VBa6OkaET6uN/mJOhHONuy3m1sgF0CV6mXdPSEBdA7e1eUbVvyNtANjMbg22JUv71BaDXLY6A==",
+      "dev": true,
+      "requires": {
+        "core-js-pure": "^3.0.0",
+        "regenerator-runtime": "^0.13.4"
+      },
+      "dependencies": {
+        "regenerator-runtime": {
+          "version": "0.13.7",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.7.tgz",
+          "integrity": "sha512-a54FxoJDIr27pgf7IgeQGxmqUNYrcV338lf/6gH456HZ/PhX+5BcwHXG9ajESmwe6WRO0tAzRUrRmNONWgkrew==",
+          "dev": true
+        }
+      }
+    },
     "@babel/template": {
       "version": "7.7.4",
       "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.7.4.tgz",
@@ -2499,6 +2642,12 @@
         "lodash": "^4.17.13",
         "to-fast-properties": "^2.0.0"
       }
+    },
+    "@bcoe/v8-coverage": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz",
+      "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
+      "dev": true
     },
     "@cnakazawa/watch": {
       "version": "1.0.3",
@@ -2622,6 +2771,39 @@
             "minimatch": "^3.0.4",
             "once": "^1.3.0",
             "path-is-absolute": "^1.0.0"
+          }
+        },
+        "jest": {
+          "version": "24.9.0",
+          "resolved": "https://registry.npmjs.org/jest/-/jest-24.9.0.tgz",
+          "integrity": "sha512-YvkBL1Zm7d2B1+h5fHEOdyjCG+sGMz4f8D86/0HiqJ6MB4MnDc8FgP5vdWsGnemOQro7lnYo8UakZ3+5A0jxGw==",
+          "dev": true,
+          "requires": {
+            "import-local": "^2.0.0",
+            "jest-cli": "^24.9.0"
+          },
+          "dependencies": {
+            "jest-cli": {
+              "version": "24.9.0",
+              "resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-24.9.0.tgz",
+              "integrity": "sha512-+VLRKyitT3BWoMeSUIHRxV/2g8y9gw91Jh5z2UmXZzkZKpbC08CSehVxgHUwTpy+HwGcns/tqafQDJW7imYvGg==",
+              "dev": true,
+              "requires": {
+                "@jest/core": "^24.9.0",
+                "@jest/test-result": "^24.9.0",
+                "@jest/types": "^24.9.0",
+                "chalk": "^2.0.1",
+                "exit": "^0.1.2",
+                "import-local": "^2.0.0",
+                "is-ci": "^2.0.0",
+                "jest-config": "^24.9.0",
+                "jest-util": "^24.9.0",
+                "jest-validate": "^24.9.0",
+                "prompts": "^2.0.1",
+                "realpath-native": "^1.1.0",
+                "yargs": "^13.3.0"
+              }
+            }
           }
         }
       }
@@ -2774,6 +2956,67 @@
         "prop-types": "^15.7.2"
       }
     },
+    "@istanbuljs/load-nyc-config": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@istanbuljs/load-nyc-config/-/load-nyc-config-1.1.0.tgz",
+      "integrity": "sha512-VjeHSlIzpv/NyD3N0YuHfXOPDIixcA1q2ZV98wsMqcYlPmv2n3Yb2lYP9XMElnaFVXg5A7YLTeLu6V84uQDjmQ==",
+      "dev": true,
+      "requires": {
+        "camelcase": "^5.3.1",
+        "find-up": "^4.1.0",
+        "get-package-type": "^0.1.0",
+        "js-yaml": "^3.13.1",
+        "resolve-from": "^5.0.0"
+      },
+      "dependencies": {
+        "find-up": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+          "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+          "dev": true,
+          "requires": {
+            "locate-path": "^5.0.0",
+            "path-exists": "^4.0.0"
+          }
+        },
+        "locate-path": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+          "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+          "dev": true,
+          "requires": {
+            "p-locate": "^4.1.0"
+          }
+        },
+        "p-locate": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+          "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+          "dev": true,
+          "requires": {
+            "p-limit": "^2.2.0"
+          }
+        },
+        "path-exists": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+          "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+          "dev": true
+        },
+        "resolve-from": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
+          "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
+          "dev": true
+        }
+      }
+    },
+    "@istanbuljs/schema": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.2.tgz",
+      "integrity": "sha512-tsAQNx32a8CoFhjhijUIhI4kccIAgmGhy8LZMZgGfmXcpMbPRUqn5LWmgRttILi6yeGmBJd2xsPkFMs0PzgPCw==",
+      "dev": true
+    },
     "@jest/console": {
       "version": "24.9.0",
       "resolved": "https://registry.npmjs.org/@jest/console/-/console-24.9.0.tgz",
@@ -2842,6 +3085,310 @@
         "@jest/types": "^24.9.0",
         "jest-message-util": "^24.9.0",
         "jest-mock": "^24.9.0"
+      }
+    },
+    "@jest/globals": {
+      "version": "26.4.2",
+      "resolved": "https://registry.npmjs.org/@jest/globals/-/globals-26.4.2.tgz",
+      "integrity": "sha512-Ot5ouAlehhHLRhc+sDz2/9bmNv9p5ZWZ9LE1pXGGTCXBasmi5jnYjlgYcYt03FBwLmZXCZ7GrL29c33/XRQiow==",
+      "dev": true,
+      "requires": {
+        "@jest/environment": "^26.3.0",
+        "@jest/types": "^26.3.0",
+        "expect": "^26.4.2"
+      },
+      "dependencies": {
+        "@jest/environment": {
+          "version": "26.3.0",
+          "resolved": "https://registry.npmjs.org/@jest/environment/-/environment-26.3.0.tgz",
+          "integrity": "sha512-EW+MFEo0DGHahf83RAaiqQx688qpXgl99wdb8Fy67ybyzHwR1a58LHcO376xQJHfmoXTu89M09dH3J509cx2AA==",
+          "dev": true,
+          "requires": {
+            "@jest/fake-timers": "^26.3.0",
+            "@jest/types": "^26.3.0",
+            "@types/node": "*",
+            "jest-mock": "^26.3.0"
+          }
+        },
+        "@jest/fake-timers": {
+          "version": "26.3.0",
+          "resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-26.3.0.tgz",
+          "integrity": "sha512-ZL9ytUiRwVP8ujfRepffokBvD2KbxbqMhrXSBhSdAhISCw3gOkuntisiSFv+A6HN0n0fF4cxzICEKZENLmW+1A==",
+          "dev": true,
+          "requires": {
+            "@jest/types": "^26.3.0",
+            "@sinonjs/fake-timers": "^6.0.1",
+            "@types/node": "*",
+            "jest-message-util": "^26.3.0",
+            "jest-mock": "^26.3.0",
+            "jest-util": "^26.3.0"
+          }
+        },
+        "@jest/types": {
+          "version": "26.3.0",
+          "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.3.0.tgz",
+          "integrity": "sha512-BDPG23U0qDeAvU4f99haztXwdAg3hz4El95LkAM+tHAqqhiVzRpEGHHU8EDxT/AnxOrA65YjLBwDahdJ9pTLJQ==",
+          "dev": true,
+          "requires": {
+            "@types/istanbul-lib-coverage": "^2.0.0",
+            "@types/istanbul-reports": "^3.0.0",
+            "@types/node": "*",
+            "@types/yargs": "^15.0.0",
+            "chalk": "^4.0.0"
+          }
+        },
+        "@types/istanbul-reports": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-3.0.0.tgz",
+          "integrity": "sha512-nwKNbvnwJ2/mndE9ItP/zc2TCzw6uuodnF4EHYWD+gCQDVBuRQL5UzbZD0/ezy1iKsFU2ZQiDqg4M9dN4+wZgA==",
+          "dev": true,
+          "requires": {
+            "@types/istanbul-lib-report": "*"
+          }
+        },
+        "@types/yargs": {
+          "version": "15.0.5",
+          "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.5.tgz",
+          "integrity": "sha512-Dk/IDOPtOgubt/IaevIUbTgV7doaKkoorvOyYM2CMwuDyP89bekI7H4xLIwunNYiK9jhCkmc6pUrJk3cj2AB9w==",
+          "dev": true,
+          "requires": {
+            "@types/yargs-parser": "*"
+          }
+        },
+        "ansi-regex": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
+          "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+          "dev": true
+        },
+        "ansi-styles": {
+          "version": "4.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+          "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+          "dev": true,
+          "requires": {
+            "@types/color-name": "^1.1.1",
+            "color-convert": "^2.0.1"
+          }
+        },
+        "braces": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
+          "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+          "dev": true,
+          "requires": {
+            "fill-range": "^7.0.1"
+          }
+        },
+        "chalk": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
+          "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        },
+        "diff-sequences": {
+          "version": "26.3.0",
+          "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-26.3.0.tgz",
+          "integrity": "sha512-5j5vdRcw3CNctePNYN0Wy2e/JbWT6cAYnXv5OuqPhDpyCGc0uLu2TK0zOCJWNB9kOIfYMSpIulRaDgIi4HJ6Ig==",
+          "dev": true
+        },
+        "escape-string-regexp": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz",
+          "integrity": "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==",
+          "dev": true
+        },
+        "expect": {
+          "version": "26.4.2",
+          "resolved": "https://registry.npmjs.org/expect/-/expect-26.4.2.tgz",
+          "integrity": "sha512-IlJ3X52Z0lDHm7gjEp+m76uX46ldH5VpqmU0006vqDju/285twh7zaWMRhs67VpQhBwjjMchk+p5aA0VkERCAA==",
+          "dev": true,
+          "requires": {
+            "@jest/types": "^26.3.0",
+            "ansi-styles": "^4.0.0",
+            "jest-get-type": "^26.3.0",
+            "jest-matcher-utils": "^26.4.2",
+            "jest-message-util": "^26.3.0",
+            "jest-regex-util": "^26.0.0"
+          }
+        },
+        "fill-range": {
+          "version": "7.0.1",
+          "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
+          "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+          "dev": true,
+          "requires": {
+            "to-regex-range": "^5.0.1"
+          }
+        },
+        "graceful-fs": {
+          "version": "4.2.4",
+          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.4.tgz",
+          "integrity": "sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw==",
+          "dev": true
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "is-number": {
+          "version": "7.0.0",
+          "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+          "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+          "dev": true
+        },
+        "jest-diff": {
+          "version": "26.4.2",
+          "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-26.4.2.tgz",
+          "integrity": "sha512-6T1XQY8U28WH0Z5rGpQ+VqZSZz8EN8rZcBtfvXaOkbwxIEeRre6qnuZQlbY1AJ4MKDxQF8EkrCvK+hL/VkyYLQ==",
+          "dev": true,
+          "requires": {
+            "chalk": "^4.0.0",
+            "diff-sequences": "^26.3.0",
+            "jest-get-type": "^26.3.0",
+            "pretty-format": "^26.4.2"
+          }
+        },
+        "jest-get-type": {
+          "version": "26.3.0",
+          "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-26.3.0.tgz",
+          "integrity": "sha512-TpfaviN1R2pQWkIihlfEanwOXK0zcxrKEE4MlU6Tn7keoXdN6/3gK/xl0yEh8DOunn5pOVGKf8hB4R9gVh04ig==",
+          "dev": true
+        },
+        "jest-matcher-utils": {
+          "version": "26.4.2",
+          "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-26.4.2.tgz",
+          "integrity": "sha512-KcbNqWfWUG24R7tu9WcAOKKdiXiXCbMvQYT6iodZ9k1f7065k0keUOW6XpJMMvah+hTfqkhJhRXmA3r3zMAg0Q==",
+          "dev": true,
+          "requires": {
+            "chalk": "^4.0.0",
+            "jest-diff": "^26.4.2",
+            "jest-get-type": "^26.3.0",
+            "pretty-format": "^26.4.2"
+          }
+        },
+        "jest-message-util": {
+          "version": "26.3.0",
+          "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-26.3.0.tgz",
+          "integrity": "sha512-xIavRYqr4/otGOiLxLZGj3ieMmjcNE73Ui+LdSW/Y790j5acqCsAdDiLIbzHCZMpN07JOENRWX5DcU+OQ+TjTA==",
+          "dev": true,
+          "requires": {
+            "@babel/code-frame": "^7.0.0",
+            "@jest/types": "^26.3.0",
+            "@types/stack-utils": "^1.0.1",
+            "chalk": "^4.0.0",
+            "graceful-fs": "^4.2.4",
+            "micromatch": "^4.0.2",
+            "slash": "^3.0.0",
+            "stack-utils": "^2.0.2"
+          }
+        },
+        "jest-mock": {
+          "version": "26.3.0",
+          "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-26.3.0.tgz",
+          "integrity": "sha512-PeaRrg8Dc6mnS35gOo/CbZovoDPKAeB1FICZiuagAgGvbWdNNyjQjkOaGUa/3N3JtpQ/Mh9P4A2D4Fv51NnP8Q==",
+          "dev": true,
+          "requires": {
+            "@jest/types": "^26.3.0",
+            "@types/node": "*"
+          }
+        },
+        "jest-regex-util": {
+          "version": "26.0.0",
+          "resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-26.0.0.tgz",
+          "integrity": "sha512-Gv3ZIs/nA48/Zvjrl34bf+oD76JHiGDUxNOVgUjh3j890sblXryjY4rss71fPtD/njchl6PSE2hIhvyWa1eT0A==",
+          "dev": true
+        },
+        "jest-util": {
+          "version": "26.3.0",
+          "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-26.3.0.tgz",
+          "integrity": "sha512-4zpn6bwV0+AMFN0IYhH/wnzIQzRaYVrz1A8sYnRnj4UXDXbOVtWmlaZkO9mipFqZ13okIfN87aDoJWB7VH6hcw==",
+          "dev": true,
+          "requires": {
+            "@jest/types": "^26.3.0",
+            "@types/node": "*",
+            "chalk": "^4.0.0",
+            "graceful-fs": "^4.2.4",
+            "is-ci": "^2.0.0",
+            "micromatch": "^4.0.2"
+          }
+        },
+        "micromatch": {
+          "version": "4.0.2",
+          "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.2.tgz",
+          "integrity": "sha512-y7FpHSbMUMoyPbYUSzO6PaZ6FyRnQOpHuKwbo1G+Knck95XVU4QAiKdGEnj5wwoS7PlOgthX/09u5iFJ+aYf5Q==",
+          "dev": true,
+          "requires": {
+            "braces": "^3.0.1",
+            "picomatch": "^2.0.5"
+          }
+        },
+        "pretty-format": {
+          "version": "26.4.2",
+          "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-26.4.2.tgz",
+          "integrity": "sha512-zK6Gd8zDsEiVydOCGLkoBoZuqv8VTiHyAbKznXe/gaph/DAeZOmit9yMfgIz5adIgAMMs5XfoYSwAX3jcCO1tA==",
+          "dev": true,
+          "requires": {
+            "@jest/types": "^26.3.0",
+            "ansi-regex": "^5.0.0",
+            "ansi-styles": "^4.0.0",
+            "react-is": "^16.12.0"
+          }
+        },
+        "slash": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
+          "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
+          "dev": true
+        },
+        "stack-utils": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-2.0.2.tgz",
+          "integrity": "sha512-0H7QK2ECz3fyZMzQ8rH0j2ykpfbnd20BFtfg/SqVC2+sCTtcw0aDTGB7dk+de4U4uUeuz6nOtJcrkFFLG1B0Rg==",
+          "dev": true,
+          "requires": {
+            "escape-string-regexp": "^2.0.0"
+          }
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        },
+        "to-regex-range": {
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+          "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+          "dev": true,
+          "requires": {
+            "is-number": "^7.0.0"
+          }
+        }
       }
     },
     "@jest/reporters": {
@@ -3264,11 +3811,35 @@
         "lodash-es": "^4.17.15"
       }
     },
+    "@sheerun/mutationobserver-shim": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/@sheerun/mutationobserver-shim/-/mutationobserver-shim-0.3.3.tgz",
+      "integrity": "sha512-DetpxZw1fzPD5xUBrIAoplLChO2VB8DlL5Gg+I1IR9b2wPqYIca2WSUxL5g1vLeR4MsQq1NeWriXAVffV+U1Fw==",
+      "dev": true
+    },
     "@sindresorhus/is": {
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-0.7.0.tgz",
       "integrity": "sha512-ONhaKPIufzzrlNbqtWFFd+jlnemX6lJAgq9ZeiZtS7I1PIf/la7CW4m83rTXRnVnsMbW2k56pGYu7AUFJD9Pow==",
       "dev": true
+    },
+    "@sinonjs/commons": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.8.1.tgz",
+      "integrity": "sha512-892K+kWUUi3cl+LlqEWIDrhvLgdL79tECi8JZUyq6IviKy/DNhuzCRlbHUjxK89f4ypPMMaFnFuR9Ie6DoIMsw==",
+      "dev": true,
+      "requires": {
+        "type-detect": "4.0.8"
+      }
+    },
+    "@sinonjs/fake-timers": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-6.0.1.tgz",
+      "integrity": "sha512-MZPUxrmFubI36XS1DI3qmI0YdN1gks62JtFZvxR67ljjSNCeK6U08Zx4msEWOXuofgqUt6zPHSi1H9fbjR/NRA==",
+      "dev": true,
+      "requires": {
+        "@sinonjs/commons": "^1.7.0"
+      }
     },
     "@svgr/babel-plugin-add-jsx-attribute": {
       "version": "4.2.0",
@@ -3393,10 +3964,231 @@
         "loader-utils": "^1.2.3"
       }
     },
+    "@testing-library/dom": {
+      "version": "7.24.2",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-7.24.2.tgz",
+      "integrity": "sha512-ERxcZSoHx0EcN4HfshySEWmEf5Kkmgi+J7O79yCJ3xggzVlBJ2w/QjJUC+EBkJJ2OeSw48i3IoePN4w8JlVUIA==",
+      "dev": true,
+      "requires": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/runtime": "^7.10.3",
+        "@types/aria-query": "^4.2.0",
+        "aria-query": "^4.2.2",
+        "chalk": "^4.1.0",
+        "dom-accessibility-api": "^0.5.1",
+        "pretty-format": "^26.4.2"
+      },
+      "dependencies": {
+        "@babel/code-frame": {
+          "version": "7.10.4",
+          "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.10.4.tgz",
+          "integrity": "sha512-vG6SvB6oYEhvgisZNFRmRCUkLz11c7rp+tbNTynGqc6mS1d5ATd/sGyV6W0KZZnXRKMTzZDRgQT3Ou9jhpAfUg==",
+          "dev": true,
+          "requires": {
+            "@babel/highlight": "^7.10.4"
+          }
+        },
+        "@babel/highlight": {
+          "version": "7.10.4",
+          "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.10.4.tgz",
+          "integrity": "sha512-i6rgnR/YgPEQzZZnbTHHuZdlE8qyoBNalD6F+q4vAFlcMEcqmkoG+mPqJYJCo63qPf74+Y1UZsl3l6f7/RIkmA==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-validator-identifier": "^7.10.4",
+            "chalk": "^2.0.0",
+            "js-tokens": "^4.0.0"
+          },
+          "dependencies": {
+            "chalk": {
+              "version": "2.4.2",
+              "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+              "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+              "dev": true,
+              "requires": {
+                "ansi-styles": "^3.2.1",
+                "escape-string-regexp": "^1.0.5",
+                "supports-color": "^5.3.0"
+              }
+            }
+          }
+        },
+        "@babel/runtime": {
+          "version": "7.11.2",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.11.2.tgz",
+          "integrity": "sha512-TeWkU52so0mPtDcaCTxNBI/IHiz0pZgr8VEFqXFtZWpYD08ZB6FaSwVAS8MKRQAP3bYKiVjwysOJgMFY28o6Tw==",
+          "dev": true,
+          "requires": {
+            "regenerator-runtime": "^0.13.4"
+          }
+        },
+        "@jest/types": {
+          "version": "26.3.0",
+          "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.3.0.tgz",
+          "integrity": "sha512-BDPG23U0qDeAvU4f99haztXwdAg3hz4El95LkAM+tHAqqhiVzRpEGHHU8EDxT/AnxOrA65YjLBwDahdJ9pTLJQ==",
+          "dev": true,
+          "requires": {
+            "@types/istanbul-lib-coverage": "^2.0.0",
+            "@types/istanbul-reports": "^3.0.0",
+            "@types/node": "*",
+            "@types/yargs": "^15.0.0",
+            "chalk": "^4.0.0"
+          }
+        },
+        "@types/istanbul-reports": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-3.0.0.tgz",
+          "integrity": "sha512-nwKNbvnwJ2/mndE9ItP/zc2TCzw6uuodnF4EHYWD+gCQDVBuRQL5UzbZD0/ezy1iKsFU2ZQiDqg4M9dN4+wZgA==",
+          "dev": true,
+          "requires": {
+            "@types/istanbul-lib-report": "*"
+          }
+        },
+        "@types/yargs": {
+          "version": "15.0.5",
+          "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.5.tgz",
+          "integrity": "sha512-Dk/IDOPtOgubt/IaevIUbTgV7doaKkoorvOyYM2CMwuDyP89bekI7H4xLIwunNYiK9jhCkmc6pUrJk3cj2AB9w==",
+          "dev": true,
+          "requires": {
+            "@types/yargs-parser": "*"
+          }
+        },
+        "ansi-regex": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
+          "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+          "dev": true
+        },
+        "aria-query": {
+          "version": "4.2.2",
+          "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-4.2.2.tgz",
+          "integrity": "sha512-o/HelwhuKpTj/frsOsbNLNgnNGVIFsVP/SW2BSF14gVl7kAfMOJ6/8wUAUvG1R1NHKrfG+2sHZTu0yauT1qBrA==",
+          "dev": true,
+          "requires": {
+            "@babel/runtime": "^7.10.2",
+            "@babel/runtime-corejs3": "^7.10.2"
+          }
+        },
+        "chalk": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
+          "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          },
+          "dependencies": {
+            "ansi-styles": {
+              "version": "4.2.1",
+              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+              "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+              "dev": true,
+              "requires": {
+                "@types/color-name": "^1.1.1",
+                "color-convert": "^2.0.1"
+              }
+            },
+            "supports-color": {
+              "version": "7.2.0",
+              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+              "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+              "dev": true,
+              "requires": {
+                "has-flag": "^4.0.0"
+              }
+            }
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "pretty-format": {
+          "version": "26.4.2",
+          "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-26.4.2.tgz",
+          "integrity": "sha512-zK6Gd8zDsEiVydOCGLkoBoZuqv8VTiHyAbKznXe/gaph/DAeZOmit9yMfgIz5adIgAMMs5XfoYSwAX3jcCO1tA==",
+          "dev": true,
+          "requires": {
+            "@jest/types": "^26.3.0",
+            "ansi-regex": "^5.0.0",
+            "ansi-styles": "^4.0.0",
+            "react-is": "^16.12.0"
+          },
+          "dependencies": {
+            "ansi-styles": {
+              "version": "4.2.1",
+              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+              "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+              "dev": true,
+              "requires": {
+                "@types/color-name": "^1.1.1",
+                "color-convert": "^2.0.1"
+              }
+            }
+          }
+        },
+        "regenerator-runtime": {
+          "version": "0.13.7",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.7.tgz",
+          "integrity": "sha512-a54FxoJDIr27pgf7IgeQGxmqUNYrcV338lf/6gH456HZ/PhX+5BcwHXG9ajESmwe6WRO0tAzRUrRmNONWgkrew==",
+          "dev": true
+        }
+      }
+    },
+    "@testing-library/react": {
+      "version": "11.0.4",
+      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-11.0.4.tgz",
+      "integrity": "sha512-U0fZO2zxm7M0CB5h1+lh31lbAwMSmDMEMGpMT3BUPJwIjDEKYWOV4dx7lb3x2Ue0Pyt77gmz/VropuJnSz/Iew==",
+      "dev": true,
+      "requires": {
+        "@babel/runtime": "^7.11.2",
+        "@testing-library/dom": "^7.24.2"
+      },
+      "dependencies": {
+        "@babel/runtime": {
+          "version": "7.11.2",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.11.2.tgz",
+          "integrity": "sha512-TeWkU52so0mPtDcaCTxNBI/IHiz0pZgr8VEFqXFtZWpYD08ZB6FaSwVAS8MKRQAP3bYKiVjwysOJgMFY28o6Tw==",
+          "dev": true,
+          "requires": {
+            "regenerator-runtime": "^0.13.4"
+          }
+        },
+        "regenerator-runtime": {
+          "version": "0.13.7",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.7.tgz",
+          "integrity": "sha512-a54FxoJDIr27pgf7IgeQGxmqUNYrcV338lf/6gH456HZ/PhX+5BcwHXG9ajESmwe6WRO0tAzRUrRmNONWgkrew==",
+          "dev": true
+        }
+      }
+    },
     "@tootallnate/once": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-1.1.2.tgz",
       "integrity": "sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw==",
+      "dev": true
+    },
+    "@types/aria-query": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-4.2.0.tgz",
+      "integrity": "sha512-iIgQNzCm0v7QMhhe4Jjn9uRh+I6GoPmt03CbEtwx3ao8/EfoQcmgtqH4vQ5Db/lxiIGaWDv6nwvunuh0RyX0+A==",
       "dev": true
     },
     "@types/babel__core": {
@@ -3445,6 +4237,12 @@
       "resolved": "https://registry.npmjs.org/@types/classnames/-/classnames-2.2.10.tgz",
       "integrity": "sha512-1UzDldn9GfYYEsWWnn/P4wkTlkZDH7lDb0wBMGbtIQc9zXEQq7FlKBdZUn6OBqD8sKZZ2RQO2mAjGpXiDGoRmQ=="
     },
+    "@types/color-name": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@types/color-name/-/color-name-1.1.1.tgz",
+      "integrity": "sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ==",
+      "dev": true
+    },
     "@types/cookie": {
       "version": "0.3.3",
       "resolved": "https://registry.npmjs.org/@types/cookie/-/cookie-0.3.3.tgz",
@@ -3464,6 +4262,15 @@
       "requires": {
         "@types/events": "*",
         "@types/minimatch": "*",
+        "@types/node": "*"
+      }
+    },
+    "@types/graceful-fs": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/@types/graceful-fs/-/graceful-fs-4.1.3.tgz",
+      "integrity": "sha512-AiHRaEB50LQg0pZmm659vNBb9f4SJ0qrAnteuzhSeAUcJKxoYgEnprg/83kppCnc2zvtCKbdZry1a5pVY3lOTQ==",
+      "dev": true,
+      "requires": {
         "@types/node": "*"
       }
     },
@@ -3498,9 +4305,9 @@
       }
     },
     "@types/json-schema": {
-      "version": "7.0.5",
-      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.5.tgz",
-      "integrity": "sha512-7+2BITlgjgDhH0vvwZU/HZJVyk+2XUlvxXe8dFMedNX/aMkaOq++rMAFXc0tM7ij15QaWlbdQASBR9dihi+bDQ==",
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.6.tgz",
+      "integrity": "sha512-3c+yGKvVP5Y9TYBEibGNR+kLtijnj7mYrXRg+WpFb2X9xm04g/DXYkfg4hmzJQosc9snFNUPkbYIhu+KAm6jJw==",
       "dev": true
     },
     "@types/minimatch": {
@@ -3525,6 +4332,12 @@
       "version": "4.0.30",
       "resolved": "https://registry.npmjs.org/@types/object-assign/-/object-assign-4.0.30.tgz",
       "integrity": "sha1-iUk3HVqZ9Dge4PHfCpt6GH4H5lI="
+    },
+    "@types/prettier": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@types/prettier/-/prettier-2.1.0.tgz",
+      "integrity": "sha512-hiYA88aHiEIgDmeKlsyVsuQdcFn3Z2VuFd/Xm/HCnGnPD8UFU5BM128uzzRVVGEzKDKYUrRsRH9S2o+NUy/3IA==",
+      "dev": true
     },
     "@types/prop-types": {
       "version": "15.7.3",
@@ -3769,9 +4582,9 @@
       "dev": true
     },
     "abab": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/abab/-/abab-2.0.3.tgz",
-      "integrity": "sha512-tsFzPpcttalNjFBCFMqsKYQcWxxen1pgJR56by//QwvJc4/OUS3kPOOttx2tSIfjsylB0pYu7f5D3K1RCxUnUg==",
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/abab/-/abab-2.0.5.tgz",
+      "integrity": "sha512-9IK9EadsbHo6jLWIpxpR6pL0sazTXV6+SQv25ZB+F7Bj9mJNaOc4nCRabwd5M/JwmUa8idz6Eci6eKfJryPs6Q==",
       "dev": true
     },
     "abbrev": {
@@ -3807,9 +4620,9 @@
       },
       "dependencies": {
         "acorn": {
-          "version": "6.4.0",
-          "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.4.0.tgz",
-          "integrity": "sha512-gac8OEcQ2Li1dxIEWGZzsp2BitJxwkwcOm0zHAJLcPJaVvm58FRnk6RkuLRpU1EujipU2ZFODv2P9DLMfnV8mw==",
+          "version": "6.4.1",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.4.1.tgz",
+          "integrity": "sha512-ZVA9k326Nwrj3Cj9jlh3wGFutC2ZornPNARZwsNYqQYgN0EsV2d53w5RN/co65Ohn4sUAUtb1rSUAOD6XN9idA==",
           "dev": true
         }
       }
@@ -3880,9 +4693,9 @@
       }
     },
     "aggregate-error": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-3.0.1.tgz",
-      "integrity": "sha512-quoaXsZ9/BLNae5yiNoUz+Nhkwz83GhWwtYFglcjEQB2NDHCIpApbqXxIFnm4Pq/Nvhrsq5sYJFyohrrxnTGAA==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-3.1.0.tgz",
+      "integrity": "sha512-4I7Td01quW/RpocfNayFdFVk1qSuoh0E7JrbRJ16nH01HhKFQ88INq9Sd+nd72zqRySlr9BmDA8xlEJ6vJMrYA==",
       "dev": true,
       "requires": {
         "clean-stack": "^2.0.0",
@@ -4519,9 +5332,9 @@
       "dev": true
     },
     "attr-accept": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/attr-accept/-/attr-accept-2.2.1.tgz",
-      "integrity": "sha512-GpefLMsbH5ojNgfTW+OBin2xKzuHfyeNA+qCktzZojBhbA/lPZdCFMWdwk5ajb989Ok7ZT+EADqvW3TAFNMjhA=="
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/attr-accept/-/attr-accept-2.2.2.tgz",
+      "integrity": "sha512-7prDjvt9HmqiZ0cl5CRjtS84sEyhsHP2coDkaZKRKVfCDo9s7iw7ChVmar78Gu9pC4SoR/28wFu/G5JJhTnqEg=="
     },
     "autoprefixer": {
       "version": "9.6.1",
@@ -4745,6 +5558,42 @@
         "babel-runtime": "^6.26.0",
         "core-js": "^2.5.0",
         "regenerator-runtime": "^0.10.5"
+      }
+    },
+    "babel-preset-current-node-syntax": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/babel-preset-current-node-syntax/-/babel-preset-current-node-syntax-0.1.3.tgz",
+      "integrity": "sha512-uyexu1sVwcdFnyq9o8UQYsXwXflIh8LvrF5+cKrYam93ned1CStffB3+BEcsxGSgagoA3GEyjDqO4a/58hyPYQ==",
+      "dev": true,
+      "requires": {
+        "@babel/plugin-syntax-async-generators": "^7.8.4",
+        "@babel/plugin-syntax-bigint": "^7.8.3",
+        "@babel/plugin-syntax-class-properties": "^7.8.3",
+        "@babel/plugin-syntax-import-meta": "^7.8.3",
+        "@babel/plugin-syntax-json-strings": "^7.8.3",
+        "@babel/plugin-syntax-logical-assignment-operators": "^7.8.3",
+        "@babel/plugin-syntax-nullish-coalescing-operator": "^7.8.3",
+        "@babel/plugin-syntax-numeric-separator": "^7.8.3",
+        "@babel/plugin-syntax-object-rest-spread": "^7.8.3",
+        "@babel/plugin-syntax-optional-catch-binding": "^7.8.3",
+        "@babel/plugin-syntax-optional-chaining": "^7.8.3"
+      },
+      "dependencies": {
+        "@babel/helper-plugin-utils": {
+          "version": "7.10.4",
+          "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.10.4.tgz",
+          "integrity": "sha512-O4KCvQA6lLiMU9l2eawBPMf1xPP8xPfB3iEQw150hOVTqj/rfXz0ThTb4HEzqQfs2Bmo5Ay8BzxfzVtBrr9dVg==",
+          "dev": true
+        },
+        "@babel/plugin-syntax-object-rest-spread": {
+          "version": "7.8.3",
+          "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-object-rest-spread/-/plugin-syntax-object-rest-spread-7.8.3.tgz",
+          "integrity": "sha512-XoqMijGZb9y3y2XskN+P1wUGiVwWZ5JmoDRwx5+3GmEplNyVM2s2Dg8ILFQm8rWM48orGy5YpI5Bl8U1y7ydlA==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-plugin-utils": "^7.8.0"
+          }
+        }
       }
     },
     "babel-preset-jest": {
@@ -5390,9 +6239,9 @@
       "dev": true
     },
     "browser-process-hrtime": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/browser-process-hrtime/-/browser-process-hrtime-0.1.3.tgz",
-      "integrity": "sha512-bRFnI4NnjO6cnyLmOV/7PVoDEMJChlcfN0z4s1YMBY989/SvlfMI1lgCnkFUs53e9gQF+w7qu7XdllSTiSl8Aw==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/browser-process-hrtime/-/browser-process-hrtime-1.0.0.tgz",
+      "integrity": "sha512-9o5UecI3GhkpM6DrXr69PblIuWxPKk9Y0jHBRhdocZ2y7YECBFCsHm79Pr3OyR2AvjhDkabFJaDJMYRazHgsow==",
       "dev": true
     },
     "browser-resolve": {
@@ -5821,6 +6670,12 @@
         "supports-color": "^5.3.0"
       }
     },
+    "char-regex": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/char-regex/-/char-regex-1.0.2.tgz",
+      "integrity": "sha512-kWWXztvZ5SBQV+eRgKFeh8q5sLuZY2+8WUIzlxWVTg+oGwY14qylx1KbKzHd8P6ZYkAg0xyIDU9JMHhyJMZ1jw==",
+      "dev": true
+    },
     "chardet": {
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.7.0.tgz",
@@ -6123,6 +6978,12 @@
         "teeny-request": "6.0.1",
         "urlgrey": "0.4.4"
       }
+    },
+    "collect-v8-coverage": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/collect-v8-coverage/-/collect-v8-coverage-1.0.1.tgz",
+      "integrity": "sha512-iBPtljfCNcTKNAto0KEtDfZ3qzjJvqE3aTGZsbhjSBlorqpXJlaWWtPO35D+ZImoC3KWejX64o+yPGxhWSTzfg==",
+      "dev": true
     },
     "collection-visit": {
       "version": "1.0.0",
@@ -6455,20 +7316,20 @@
       "dev": true
     },
     "copy-webpack-plugin": {
-      "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/copy-webpack-plugin/-/copy-webpack-plugin-6.0.3.tgz",
-      "integrity": "sha512-q5m6Vz4elsuyVEIUXr7wJdIdePWTubsqVbEMvf1WQnHGv0Q+9yPRu7MtYFPt+GBOXRav9lvIINifTQ1vSCs+eA==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/copy-webpack-plugin/-/copy-webpack-plugin-6.1.0.tgz",
+      "integrity": "sha512-aWjIuLt1OVQxaDVffnt3bnGmLA8zGgAJaFwPA+a+QYVPh1vhIKjVfh3SbOFLV0kRPvGBITbw17n5CsmiBS4LQQ==",
       "dev": true,
       "requires": {
-        "cacache": "^15.0.4",
+        "cacache": "^15.0.5",
         "fast-glob": "^3.2.4",
         "find-cache-dir": "^3.3.1",
         "glob-parent": "^5.1.1",
         "globby": "^11.0.1",
         "loader-utils": "^2.0.0",
         "normalize-path": "^3.0.0",
-        "p-limit": "^3.0.1",
-        "schema-utils": "^2.7.0",
+        "p-limit": "^3.0.2",
+        "schema-utils": "^2.7.1",
         "serialize-javascript": "^4.0.0",
         "webpack-sources": "^1.4.3"
       },
@@ -6480,9 +7341,9 @@
           "dev": true
         },
         "ajv": {
-          "version": "6.12.3",
-          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.3.tgz",
-          "integrity": "sha512-4K0cK3L1hsqk9xIb2z9vs/XU+PGJZ9PNpJRDS9YLzmNdX6jmVPfamLvTJr0aDAusnHyCHO6MjzlkAsgtqp9teA==",
+          "version": "6.12.5",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.5.tgz",
+          "integrity": "sha512-lRF8RORchjpKG50/WFf8xmg7sgCLFiYNNnqdKflk63whMQcWR5ngGjiSXkL9bjxy6B2npOK2HSMN49jEBMSkag==",
           "dev": true,
           "requires": {
             "fast-deep-equal": "^3.1.1",
@@ -6490,6 +7351,12 @@
             "json-schema-traverse": "^0.4.1",
             "uri-js": "^4.2.2"
           }
+        },
+        "ajv-keywords": {
+          "version": "3.5.2",
+          "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.5.2.tgz",
+          "integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==",
+          "dev": true
         },
         "array-union": {
           "version": "2.1.0",
@@ -6775,14 +7642,14 @@
           }
         },
         "schema-utils": {
-          "version": "2.7.0",
-          "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-2.7.0.tgz",
-          "integrity": "sha512-0ilKFI6QQF5nxDZLFn2dMjvc4hjg/Wkg7rHd3jK6/A4a1Hl9VFdQWvgB1UMGoU94pad1P/8N7fMcEnLnSiju8A==",
+          "version": "2.7.1",
+          "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-2.7.1.tgz",
+          "integrity": "sha512-SHiNtMOUGWBQJwzISiVYKu82GiV4QYGePp3odlY1tuKO7gPtphAT5R/py0fA6xtbgLL/RvtJZnU9b8s0F1q0Xg==",
           "dev": true,
           "requires": {
-            "@types/json-schema": "^7.0.4",
-            "ajv": "^6.12.2",
-            "ajv-keywords": "^3.4.1"
+            "@types/json-schema": "^7.0.5",
+            "ajv": "^6.12.4",
+            "ajv-keywords": "^3.5.2"
           }
         },
         "semver": {
@@ -6816,15 +7683,15 @@
           }
         },
         "tar": {
-          "version": "6.0.2",
-          "resolved": "https://registry.npmjs.org/tar/-/tar-6.0.2.tgz",
-          "integrity": "sha512-Glo3jkRtPcvpDlAs/0+hozav78yoXKFr+c4wgw62NNMO3oo4AaJdCo21Uu7lcwr55h39W2XD1LMERc64wtbItg==",
+          "version": "6.0.5",
+          "resolved": "https://registry.npmjs.org/tar/-/tar-6.0.5.tgz",
+          "integrity": "sha512-0b4HOimQHj9nXNEAA7zWwMM91Zhhba3pspja6sQbgTpynOJf+bkjBnfybNYzbpLbnwXnbyB4LOREvlyXLkCHSg==",
           "dev": true,
           "requires": {
             "chownr": "^2.0.0",
             "fs-minipass": "^2.0.0",
             "minipass": "^3.0.0",
-            "minizlib": "^2.1.0",
+            "minizlib": "^2.1.1",
             "mkdirp": "^1.0.3",
             "yallist": "^4.0.0"
           }
@@ -6868,6 +7735,12 @@
           "dev": true
         }
       }
+    },
+    "core-js-pure": {
+      "version": "3.6.5",
+      "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.6.5.tgz",
+      "integrity": "sha512-lacdXOimsiD0QyNf9BC/mxivNJ/ybBGJXQFKzRekp1WTHoVUWsUHEn+2T8GJAzzIhyOuXA+gOxCVN3l+5PLPUA==",
+      "dev": true
     },
     "core-util-is": {
       "version": "1.0.2",
@@ -7268,6 +8141,12 @@
       "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
       "dev": true
     },
+    "decimal.js": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.2.0.tgz",
+      "integrity": "sha512-vDPw+rDgn3bZe1+F/pyEwb1oMG2XTlRVgAa6B4KccTEpYgF8w6eQllVbQcfIJnZyvzFtFpxnpGtx8dd7DJp/Rw==",
+      "dev": true
+    },
     "decode-uri-component": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
@@ -7437,6 +8316,12 @@
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
       "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
+      "dev": true
+    },
+    "deepmerge": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.2.2.tgz",
+      "integrity": "sha512-FJ3UgI4gIl+PHZm53knsuSFpE+nESMr7M4v9QcgB7S63Kj/6WqMiFQJpBBYz1Pt+66bZpP3Q7Lye0Oo9MPKEdg==",
       "dev": true
     },
     "default-gateway": {
@@ -7679,6 +8564,12 @@
       "requires": {
         "esutils": "^2.0.2"
       }
+    },
+    "dom-accessibility-api": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.2.tgz",
+      "integrity": "sha512-k7hRNKAiPJXD2aBqfahSo4/01cTsKWXf+LqJgglnkN2Nz8TsxXKQBXHhKe0Ye9fEfHEZY49uSA5Sr3AqP/sWKA==",
+      "dev": true
     },
     "dom-converter": {
       "version": "0.2.0",
@@ -7989,6 +8880,12 @@
       "resolved": "https://registry.npmjs.org/email-validator/-/email-validator-2.0.4.tgz",
       "integrity": "sha512-gYCwo7kh5S3IDyZPLZf6hSS0MnZT8QmJFqYvbqlDZSbwdZlY6QZWxJ4i/6UhITOJ4XzyI647Bm2MXKCLqnJ4nQ=="
     },
+    "emittery": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/emittery/-/emittery-0.7.1.tgz",
+      "integrity": "sha512-d34LN4L6h18Bzz9xpoku2nPwKxCPlPMr3EEKTkoEBi+1/+b0lcRkRJ1UVyyZaKNeqGR3swcGl6s390DNO4YVgQ==",
+      "dev": true
+    },
     "emoji-regex": {
       "version": "7.0.3",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
@@ -8190,24 +9087,16 @@
       "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
     },
     "escodegen": {
-      "version": "1.12.0",
-      "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.12.0.tgz",
-      "integrity": "sha512-TuA+EhsanGcme5T3R0L80u4t8CpbXQjegRmf7+FPTJrtCTErXFeelblRgHQa1FofEzqYYJmJ/OqjTwREp9qgmg==",
+      "version": "1.14.3",
+      "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.14.3.tgz",
+      "integrity": "sha512-qFcX0XJkdg+PB3xjZZG/wKSuT1PnQWx57+TVSjIMmILd2yC/6ByYElPwJnslDsuWuSAp4AwJGumarAAmJch5Kw==",
       "dev": true,
       "requires": {
-        "esprima": "^3.1.3",
+        "esprima": "^4.0.1",
         "estraverse": "^4.2.0",
         "esutils": "^2.0.2",
         "optionator": "^0.8.1",
         "source-map": "~0.6.1"
-      },
-      "dependencies": {
-        "esprima": {
-          "version": "3.1.3",
-          "resolved": "https://registry.npmjs.org/esprima/-/esprima-3.1.3.tgz",
-          "integrity": "sha1-/cpRzuYTOJXjyI1TXOSdv/YqRjM=",
-          "dev": true
-        }
       }
     },
     "eslint": {
@@ -9269,11 +10158,18 @@
       }
     },
     "file-selector": {
-      "version": "0.1.12",
-      "resolved": "https://registry.npmjs.org/file-selector/-/file-selector-0.1.12.tgz",
-      "integrity": "sha512-Kx7RTzxyQipHuiqyZGf+Nz4vY9R1XGxuQl/hLoJwq+J4avk/9wxxgZyHKtbyIPJmbD4A66DWGYfyykWNpcYutQ==",
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/file-selector/-/file-selector-0.1.13.tgz",
+      "integrity": "sha512-T2efCBY6Ps+jLIWdNQsmzt/UnAjKOEAlsZVdnQztg/BtAZGNL4uX1Jet9cMM8gify/x4CSudreji2HssGBNVIQ==",
       "requires": {
-        "tslib": "^1.9.0"
+        "tslib": "^2.0.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.0.1.tgz",
+          "integrity": "sha512-SgIkNheinmEBgx1IUNirK0TUD4X9yjjBRTqqjggWCU3pUEqIk3/Uwl3yRixYKT6WjQuGiwDv4NomL3wqRCj+CQ=="
+        }
       }
     },
     "file-type": {
@@ -9868,10 +10764,22 @@
         "globule": "^1.0.0"
       }
     },
+    "gensync": {
+      "version": "1.0.0-beta.1",
+      "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.1.tgz",
+      "integrity": "sha512-r8EC6NO1sngH/zdD9fiRDLdcgnbayXah+mLgManTaIZJqEC1MZstmnox8KpnI2/fxQwrp5OpCOYWLp4rBl4Jcg==",
+      "dev": true
+    },
     "get-caller-file": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
       "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "dev": true
+    },
+    "get-package-type": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/get-package-type/-/get-package-type-0.1.0.tgz",
+      "integrity": "sha512-pjzuKtY64GYfWizNAJ0fr9VqttZkNiK2iS430LtIHzjBEr6bX8Am2zm4sW4Ro5wjWW5cAlRL1qAMTcXbjNAO2Q==",
       "dev": true
     },
     "get-proxy": {
@@ -10100,18 +11008,6 @@
       "resolved": "https://registry.npmjs.org/handle-thing/-/handle-thing-2.0.0.tgz",
       "integrity": "sha512-d4sze1JNC454Wdo2fkuyzCr6aHcbL6PGGuFAz0Li/NcOm1tCHGnWDRmJP85dh9IhQErTc2svWFEX5xHIOo//kQ==",
       "dev": true
-    },
-    "handlebars": {
-      "version": "4.5.3",
-      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.5.3.tgz",
-      "integrity": "sha512-3yPecJoJHK/4c6aZhSvxOyG4vJKDshV36VHp0iVCDVh7o9w2vwi3NSnL2MMPj3YdduqaBcu7cGbggJQM0br9xA==",
-      "dev": true,
-      "requires": {
-        "neo-async": "^2.6.0",
-        "optimist": "^0.6.1",
-        "source-map": "^0.6.1",
-        "uglify-js": "^3.1.4"
-      }
     },
     "har-schema": {
       "version": "2.0.0",
@@ -10397,6 +11293,12 @@
       "integrity": "sha1-DfKTUfByEWNRXfueVUPl9u7VFi8=",
       "dev": true
     },
+    "html-escaper": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
+      "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
+      "dev": true
+    },
     "html-minifier": {
       "version": "3.5.21",
       "resolved": "https://registry.npmjs.org/html-minifier/-/html-minifier-3.5.21.tgz",
@@ -10632,6 +11534,12 @@
           "dev": true
         }
       }
+    },
+    "human-signals": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-1.1.1.tgz",
+      "integrity": "sha512-SEQu7vl8KjNL2eoGBLF3+wAjpsNfA9XMlXAYj/3EdaNfAlxKthD1xjEQfGOUhllCGGJVNY34bRr6lPINhNjyZw==",
+      "dev": true
     },
     "husky": {
       "version": "3.1.0",
@@ -11382,6 +12290,13 @@
       "integrity": "sha1-YTObbyR1/Hcv2cnYP1yFddwVSuE=",
       "dev": true
     },
+    "is-docker": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-2.1.1.tgz",
+      "integrity": "sha512-ZOoqiXfEwtGknTiuDEy8pN2CfE3TxMHprvNer1mXiqwkOT77Rw3YVrUQ52EqAOU3QAWDQ+bQdx7HJzrv7LS2Hw==",
+      "dev": true,
+      "optional": true
+    },
     "is-extendable": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
@@ -11557,6 +12472,12 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/is-png/-/is-png-1.1.0.tgz",
       "integrity": "sha1-1XSxK/J1wDUEVVcLDltXqwYgd84=",
+      "dev": true
+    },
+    "is-potential-custom-element-name": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.0.tgz",
+      "integrity": "sha1-DFLlS8yjkbssSUsh6GJtczbG45c=",
       "dev": true
     },
     "is-promise": {
@@ -11759,12 +12680,12 @@
       }
     },
     "istanbul-reports": {
-      "version": "2.2.6",
-      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-2.2.6.tgz",
-      "integrity": "sha512-SKi4rnMyLBKe0Jy2uUdx28h8oG7ph2PPuQPvIAh31d+Ci+lSiEu4C+h3oBPuJ9+mPKhOyW0M8gY4U5NM1WLeXA==",
+      "version": "2.2.7",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-2.2.7.tgz",
+      "integrity": "sha512-uu1F/L1o5Y6LzPVSVZXNOoD/KXpJue9aeLRd0sM9uMXfZvzomB0WxVamWb5ue8kA2vVWEmW7EG+A5n3f1kqHKg==",
       "dev": true,
       "requires": {
-        "handlebars": "^4.1.2"
+        "html-escaper": "^2.0.0"
       }
     },
     "isurl": {
@@ -11778,34 +12699,1915 @@
       }
     },
     "jest": {
-      "version": "24.9.0",
-      "resolved": "https://registry.npmjs.org/jest/-/jest-24.9.0.tgz",
-      "integrity": "sha512-YvkBL1Zm7d2B1+h5fHEOdyjCG+sGMz4f8D86/0HiqJ6MB4MnDc8FgP5vdWsGnemOQro7lnYo8UakZ3+5A0jxGw==",
+      "version": "26.4.2",
+      "resolved": "https://registry.npmjs.org/jest/-/jest-26.4.2.tgz",
+      "integrity": "sha512-LLCjPrUh98Ik8CzW8LLVnSCfLaiY+wbK53U7VxnFSX7Q+kWC4noVeDvGWIFw0Amfq1lq2VfGm7YHWSLBV62MJw==",
       "dev": true,
       "requires": {
-        "import-local": "^2.0.0",
-        "jest-cli": "^24.9.0"
+        "@jest/core": "^26.4.2",
+        "import-local": "^3.0.2",
+        "jest-cli": "^26.4.2"
       },
       "dependencies": {
-        "jest-cli": {
-          "version": "24.9.0",
-          "resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-24.9.0.tgz",
-          "integrity": "sha512-+VLRKyitT3BWoMeSUIHRxV/2g8y9gw91Jh5z2UmXZzkZKpbC08CSehVxgHUwTpy+HwGcns/tqafQDJW7imYvGg==",
+        "@babel/generator": {
+          "version": "7.11.6",
+          "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.11.6.tgz",
+          "integrity": "sha512-DWtQ1PV3r+cLbySoHrwn9RWEgKMBLLma4OBQloPRyDYvc5msJM9kvTLo1YnlJd1P/ZuKbdli3ijr5q3FvAF3uA==",
           "dev": true,
           "requires": {
-            "@jest/core": "^24.9.0",
-            "@jest/test-result": "^24.9.0",
-            "@jest/types": "^24.9.0",
-            "chalk": "^2.0.1",
+            "@babel/types": "^7.11.5",
+            "jsesc": "^2.5.1",
+            "source-map": "^0.5.0"
+          },
+          "dependencies": {
+            "source-map": {
+              "version": "0.5.7",
+              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+              "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+              "dev": true
+            }
+          }
+        },
+        "@babel/helper-function-name": {
+          "version": "7.10.4",
+          "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.10.4.tgz",
+          "integrity": "sha512-YdaSyz1n8gY44EmN7x44zBn9zQ1Ry2Y+3GTA+3vH6Mizke1Vw0aWDM66FOYEPw8//qKkmqOckrGgTYa+6sceqQ==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-get-function-arity": "^7.10.4",
+            "@babel/template": "^7.10.4",
+            "@babel/types": "^7.10.4"
+          }
+        },
+        "@babel/helper-get-function-arity": {
+          "version": "7.10.4",
+          "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.10.4.tgz",
+          "integrity": "sha512-EkN3YDB+SRDgiIUnNgcmiD361ti+AVbL3f3Henf6dqqUyr5dMsorno0lJWJuLhDhkI5sYEpgj6y9kB8AOU1I2A==",
+          "dev": true,
+          "requires": {
+            "@babel/types": "^7.10.4"
+          }
+        },
+        "@babel/helper-member-expression-to-functions": {
+          "version": "7.11.0",
+          "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.11.0.tgz",
+          "integrity": "sha512-JbFlKHFntRV5qKw3YC0CvQnDZ4XMwgzzBbld7Ly4Mj4cbFy3KywcR8NtNctRToMWJOVvLINJv525Gd6wwVEx/Q==",
+          "dev": true,
+          "requires": {
+            "@babel/types": "^7.11.0"
+          }
+        },
+        "@babel/helper-module-imports": {
+          "version": "7.10.4",
+          "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.10.4.tgz",
+          "integrity": "sha512-nEQJHqYavI217oD9+s5MUBzk6x1IlvoS9WTPfgG43CbMEeStE0v+r+TucWdx8KFGowPGvyOkDT9+7DHedIDnVw==",
+          "dev": true,
+          "requires": {
+            "@babel/types": "^7.10.4"
+          }
+        },
+        "@babel/helper-module-transforms": {
+          "version": "7.11.0",
+          "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.11.0.tgz",
+          "integrity": "sha512-02EVu8COMuTRO1TAzdMtpBPbe6aQ1w/8fePD2YgQmxZU4gpNWaL9gK3Jp7dxlkUlUCJOTaSeA+Hrm1BRQwqIhg==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-module-imports": "^7.10.4",
+            "@babel/helper-replace-supers": "^7.10.4",
+            "@babel/helper-simple-access": "^7.10.4",
+            "@babel/helper-split-export-declaration": "^7.11.0",
+            "@babel/template": "^7.10.4",
+            "@babel/types": "^7.11.0",
+            "lodash": "^4.17.19"
+          }
+        },
+        "@babel/helper-optimise-call-expression": {
+          "version": "7.10.4",
+          "resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.10.4.tgz",
+          "integrity": "sha512-n3UGKY4VXwXThEiKrgRAoVPBMqeoPgHVqiHZOanAJCG9nQUL2pLRQirUzl0ioKclHGpGqRgIOkgcIJaIWLpygg==",
+          "dev": true,
+          "requires": {
+            "@babel/types": "^7.10.4"
+          }
+        },
+        "@babel/helper-replace-supers": {
+          "version": "7.10.4",
+          "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.10.4.tgz",
+          "integrity": "sha512-sPxZfFXocEymYTdVK1UNmFPBN+Hv5mJkLPsYWwGBxZAxaWfFu+xqp7b6qWD0yjNuNL2VKc6L5M18tOXUP7NU0A==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-member-expression-to-functions": "^7.10.4",
+            "@babel/helper-optimise-call-expression": "^7.10.4",
+            "@babel/traverse": "^7.10.4",
+            "@babel/types": "^7.10.4"
+          }
+        },
+        "@babel/helper-simple-access": {
+          "version": "7.10.4",
+          "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.10.4.tgz",
+          "integrity": "sha512-0fMy72ej/VEvF8ULmX6yb5MtHG4uH4Dbd6I/aHDb/JVg0bbivwt9Wg+h3uMvX+QSFtwr5MeItvazbrc4jtRAXw==",
+          "dev": true,
+          "requires": {
+            "@babel/template": "^7.10.4",
+            "@babel/types": "^7.10.4"
+          }
+        },
+        "@babel/helper-split-export-declaration": {
+          "version": "7.11.0",
+          "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.11.0.tgz",
+          "integrity": "sha512-74Vejvp6mHkGE+m+k5vHY93FX2cAtrw1zXrZXRlG4l410Nm9PxfEiVTn1PjDPV5SnmieiueY4AFg2xqhNFuuZg==",
+          "dev": true,
+          "requires": {
+            "@babel/types": "^7.11.0"
+          }
+        },
+        "@babel/helpers": {
+          "version": "7.10.4",
+          "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.10.4.tgz",
+          "integrity": "sha512-L2gX/XeUONeEbI78dXSrJzGdz4GQ+ZTA/aazfUsFaWjSe95kiCuOZ5HsXvkiw3iwF+mFHSRUfJU8t6YavocdXA==",
+          "dev": true,
+          "requires": {
+            "@babel/template": "^7.10.4",
+            "@babel/traverse": "^7.10.4",
+            "@babel/types": "^7.10.4"
+          }
+        },
+        "@babel/highlight": {
+          "version": "7.10.4",
+          "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.10.4.tgz",
+          "integrity": "sha512-i6rgnR/YgPEQzZZnbTHHuZdlE8qyoBNalD6F+q4vAFlcMEcqmkoG+mPqJYJCo63qPf74+Y1UZsl3l6f7/RIkmA==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-validator-identifier": "^7.10.4",
+            "chalk": "^2.0.0",
+            "js-tokens": "^4.0.0"
+          },
+          "dependencies": {
+            "ansi-styles": {
+              "version": "3.2.1",
+              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+              "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+              "dev": true,
+              "requires": {
+                "color-convert": "^1.9.0"
+              }
+            },
+            "chalk": {
+              "version": "2.4.2",
+              "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+              "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+              "dev": true,
+              "requires": {
+                "ansi-styles": "^3.2.1",
+                "escape-string-regexp": "^1.0.5",
+                "supports-color": "^5.3.0"
+              }
+            },
+            "color-convert": {
+              "version": "1.9.3",
+              "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+              "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+              "dev": true,
+              "requires": {
+                "color-name": "1.1.3"
+              }
+            },
+            "color-name": {
+              "version": "1.1.3",
+              "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+              "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+              "dev": true
+            },
+            "escape-string-regexp": {
+              "version": "1.0.5",
+              "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+              "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+              "dev": true
+            },
+            "has-flag": {
+              "version": "3.0.0",
+              "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+              "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+              "dev": true
+            },
+            "supports-color": {
+              "version": "5.5.0",
+              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+              "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+              "dev": true,
+              "requires": {
+                "has-flag": "^3.0.0"
+              }
+            }
+          }
+        },
+        "@babel/parser": {
+          "version": "7.11.5",
+          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.11.5.tgz",
+          "integrity": "sha512-X9rD8qqm695vgmeaQ4fvz/o3+Wk4ZzQvSHkDBgpYKxpD4qTAUm88ZKtHkVqIOsYFFbIQ6wQYhC6q7pjqVK0E0Q==",
+          "dev": true
+        },
+        "@babel/template": {
+          "version": "7.10.4",
+          "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.10.4.tgz",
+          "integrity": "sha512-ZCjD27cGJFUB6nmCB1Enki3r+L5kJveX9pq1SvAUKoICy6CZ9yD8xO086YXdYhvNjBdnekm4ZnaP5yC8Cs/1tA==",
+          "dev": true,
+          "requires": {
+            "@babel/code-frame": "^7.10.4",
+            "@babel/parser": "^7.10.4",
+            "@babel/types": "^7.10.4"
+          },
+          "dependencies": {
+            "@babel/code-frame": {
+              "version": "7.10.4",
+              "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.10.4.tgz",
+              "integrity": "sha512-vG6SvB6oYEhvgisZNFRmRCUkLz11c7rp+tbNTynGqc6mS1d5ATd/sGyV6W0KZZnXRKMTzZDRgQT3Ou9jhpAfUg==",
+              "dev": true,
+              "requires": {
+                "@babel/highlight": "^7.10.4"
+              }
+            }
+          }
+        },
+        "@babel/traverse": {
+          "version": "7.11.5",
+          "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.11.5.tgz",
+          "integrity": "sha512-EjiPXt+r7LiCZXEfRpSJd+jUMnBd4/9OUv7Nx3+0u9+eimMwJmG0Q98lw4/289JCoxSE8OolDMNZaaF/JZ69WQ==",
+          "dev": true,
+          "requires": {
+            "@babel/code-frame": "^7.10.4",
+            "@babel/generator": "^7.11.5",
+            "@babel/helper-function-name": "^7.10.4",
+            "@babel/helper-split-export-declaration": "^7.11.0",
+            "@babel/parser": "^7.11.5",
+            "@babel/types": "^7.11.5",
+            "debug": "^4.1.0",
+            "globals": "^11.1.0",
+            "lodash": "^4.17.19"
+          },
+          "dependencies": {
+            "@babel/code-frame": {
+              "version": "7.10.4",
+              "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.10.4.tgz",
+              "integrity": "sha512-vG6SvB6oYEhvgisZNFRmRCUkLz11c7rp+tbNTynGqc6mS1d5ATd/sGyV6W0KZZnXRKMTzZDRgQT3Ou9jhpAfUg==",
+              "dev": true,
+              "requires": {
+                "@babel/highlight": "^7.10.4"
+              }
+            }
+          }
+        },
+        "@babel/types": {
+          "version": "7.11.5",
+          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.11.5.tgz",
+          "integrity": "sha512-bvM7Qz6eKnJVFIn+1LPtjlBFPVN5jNDc1XmN15vWe7Q3DPBufWWsLiIvUu7xW87uTG6QoggpIDnUgLQvPheU+Q==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-validator-identifier": "^7.10.4",
+            "lodash": "^4.17.19",
+            "to-fast-properties": "^2.0.0"
+          }
+        },
+        "@jest/console": {
+          "version": "26.3.0",
+          "resolved": "https://registry.npmjs.org/@jest/console/-/console-26.3.0.tgz",
+          "integrity": "sha512-/5Pn6sJev0nPUcAdpJHMVIsA8sKizL2ZkcKPE5+dJrCccks7tcM7c9wbgHudBJbxXLoTbqsHkG1Dofoem4F09w==",
+          "dev": true,
+          "requires": {
+            "@jest/types": "^26.3.0",
+            "@types/node": "*",
+            "chalk": "^4.0.0",
+            "jest-message-util": "^26.3.0",
+            "jest-util": "^26.3.0",
+            "slash": "^3.0.0"
+          }
+        },
+        "@jest/core": {
+          "version": "26.4.2",
+          "resolved": "https://registry.npmjs.org/@jest/core/-/core-26.4.2.tgz",
+          "integrity": "sha512-sDva7YkeNprxJfepOctzS8cAk9TOekldh+5FhVuXS40+94SHbiicRO1VV2tSoRtgIo+POs/Cdyf8p76vPTd6dg==",
+          "dev": true,
+          "requires": {
+            "@jest/console": "^26.3.0",
+            "@jest/reporters": "^26.4.1",
+            "@jest/test-result": "^26.3.0",
+            "@jest/transform": "^26.3.0",
+            "@jest/types": "^26.3.0",
+            "@types/node": "*",
+            "ansi-escapes": "^4.2.1",
+            "chalk": "^4.0.0",
             "exit": "^0.1.2",
-            "import-local": "^2.0.0",
+            "graceful-fs": "^4.2.4",
+            "jest-changed-files": "^26.3.0",
+            "jest-config": "^26.4.2",
+            "jest-haste-map": "^26.3.0",
+            "jest-message-util": "^26.3.0",
+            "jest-regex-util": "^26.0.0",
+            "jest-resolve": "^26.4.0",
+            "jest-resolve-dependencies": "^26.4.2",
+            "jest-runner": "^26.4.2",
+            "jest-runtime": "^26.4.2",
+            "jest-snapshot": "^26.4.2",
+            "jest-util": "^26.3.0",
+            "jest-validate": "^26.4.2",
+            "jest-watcher": "^26.3.0",
+            "micromatch": "^4.0.2",
+            "p-each-series": "^2.1.0",
+            "rimraf": "^3.0.0",
+            "slash": "^3.0.0",
+            "strip-ansi": "^6.0.0"
+          }
+        },
+        "@jest/environment": {
+          "version": "26.3.0",
+          "resolved": "https://registry.npmjs.org/@jest/environment/-/environment-26.3.0.tgz",
+          "integrity": "sha512-EW+MFEo0DGHahf83RAaiqQx688qpXgl99wdb8Fy67ybyzHwR1a58LHcO376xQJHfmoXTu89M09dH3J509cx2AA==",
+          "dev": true,
+          "requires": {
+            "@jest/fake-timers": "^26.3.0",
+            "@jest/types": "^26.3.0",
+            "@types/node": "*",
+            "jest-mock": "^26.3.0"
+          }
+        },
+        "@jest/fake-timers": {
+          "version": "26.3.0",
+          "resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-26.3.0.tgz",
+          "integrity": "sha512-ZL9ytUiRwVP8ujfRepffokBvD2KbxbqMhrXSBhSdAhISCw3gOkuntisiSFv+A6HN0n0fF4cxzICEKZENLmW+1A==",
+          "dev": true,
+          "requires": {
+            "@jest/types": "^26.3.0",
+            "@sinonjs/fake-timers": "^6.0.1",
+            "@types/node": "*",
+            "jest-message-util": "^26.3.0",
+            "jest-mock": "^26.3.0",
+            "jest-util": "^26.3.0"
+          }
+        },
+        "@jest/reporters": {
+          "version": "26.4.1",
+          "resolved": "https://registry.npmjs.org/@jest/reporters/-/reporters-26.4.1.tgz",
+          "integrity": "sha512-aROTkCLU8++yiRGVxLsuDmZsQEKO6LprlrxtAuzvtpbIFl3eIjgIf3EUxDKgomkS25R9ZzwGEdB5weCcBZlrpQ==",
+          "dev": true,
+          "requires": {
+            "@bcoe/v8-coverage": "^0.2.3",
+            "@jest/console": "^26.3.0",
+            "@jest/test-result": "^26.3.0",
+            "@jest/transform": "^26.3.0",
+            "@jest/types": "^26.3.0",
+            "chalk": "^4.0.0",
+            "collect-v8-coverage": "^1.0.0",
+            "exit": "^0.1.2",
+            "glob": "^7.1.2",
+            "graceful-fs": "^4.2.4",
+            "istanbul-lib-coverage": "^3.0.0",
+            "istanbul-lib-instrument": "^4.0.3",
+            "istanbul-lib-report": "^3.0.0",
+            "istanbul-lib-source-maps": "^4.0.0",
+            "istanbul-reports": "^3.0.2",
+            "jest-haste-map": "^26.3.0",
+            "jest-resolve": "^26.4.0",
+            "jest-util": "^26.3.0",
+            "jest-worker": "^26.3.0",
+            "node-notifier": "^8.0.0",
+            "slash": "^3.0.0",
+            "source-map": "^0.6.0",
+            "string-length": "^4.0.1",
+            "terminal-link": "^2.0.0",
+            "v8-to-istanbul": "^5.0.1"
+          }
+        },
+        "@jest/source-map": {
+          "version": "26.3.0",
+          "resolved": "https://registry.npmjs.org/@jest/source-map/-/source-map-26.3.0.tgz",
+          "integrity": "sha512-hWX5IHmMDWe1kyrKl7IhFwqOuAreIwHhbe44+XH2ZRHjrKIh0LO5eLQ/vxHFeAfRwJapmxuqlGAEYLadDq6ZGQ==",
+          "dev": true,
+          "requires": {
+            "callsites": "^3.0.0",
+            "graceful-fs": "^4.2.4",
+            "source-map": "^0.6.0"
+          }
+        },
+        "@jest/test-result": {
+          "version": "26.3.0",
+          "resolved": "https://registry.npmjs.org/@jest/test-result/-/test-result-26.3.0.tgz",
+          "integrity": "sha512-a8rbLqzW/q7HWheFVMtghXV79Xk+GWwOK1FrtimpI5n1la2SY0qHri3/b0/1F0Ve0/yJmV8pEhxDfVwiUBGtgg==",
+          "dev": true,
+          "requires": {
+            "@jest/console": "^26.3.0",
+            "@jest/types": "^26.3.0",
+            "@types/istanbul-lib-coverage": "^2.0.0",
+            "collect-v8-coverage": "^1.0.0"
+          }
+        },
+        "@jest/test-sequencer": {
+          "version": "26.4.2",
+          "resolved": "https://registry.npmjs.org/@jest/test-sequencer/-/test-sequencer-26.4.2.tgz",
+          "integrity": "sha512-83DRD8N3M0tOhz9h0bn6Kl6dSp+US6DazuVF8J9m21WAp5x7CqSMaNycMP0aemC/SH/pDQQddbsfHRTBXVUgog==",
+          "dev": true,
+          "requires": {
+            "@jest/test-result": "^26.3.0",
+            "graceful-fs": "^4.2.4",
+            "jest-haste-map": "^26.3.0",
+            "jest-runner": "^26.4.2",
+            "jest-runtime": "^26.4.2"
+          }
+        },
+        "@jest/transform": {
+          "version": "26.3.0",
+          "resolved": "https://registry.npmjs.org/@jest/transform/-/transform-26.3.0.tgz",
+          "integrity": "sha512-Isj6NB68QorGoFWvcOjlUhpkT56PqNIsXKR7XfvoDlCANn/IANlh8DrKAA2l2JKC3yWSMH5wS0GwuQM20w3b2A==",
+          "dev": true,
+          "requires": {
+            "@babel/core": "^7.1.0",
+            "@jest/types": "^26.3.0",
+            "babel-plugin-istanbul": "^6.0.0",
+            "chalk": "^4.0.0",
+            "convert-source-map": "^1.4.0",
+            "fast-json-stable-stringify": "^2.0.0",
+            "graceful-fs": "^4.2.4",
+            "jest-haste-map": "^26.3.0",
+            "jest-regex-util": "^26.0.0",
+            "jest-util": "^26.3.0",
+            "micromatch": "^4.0.2",
+            "pirates": "^4.0.1",
+            "slash": "^3.0.0",
+            "source-map": "^0.6.1",
+            "write-file-atomic": "^3.0.0"
+          }
+        },
+        "@jest/types": {
+          "version": "26.3.0",
+          "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.3.0.tgz",
+          "integrity": "sha512-BDPG23U0qDeAvU4f99haztXwdAg3hz4El95LkAM+tHAqqhiVzRpEGHHU8EDxT/AnxOrA65YjLBwDahdJ9pTLJQ==",
+          "dev": true,
+          "requires": {
+            "@types/istanbul-lib-coverage": "^2.0.0",
+            "@types/istanbul-reports": "^3.0.0",
+            "@types/node": "*",
+            "@types/yargs": "^15.0.0",
+            "chalk": "^4.0.0"
+          }
+        },
+        "@types/babel__core": {
+          "version": "7.1.9",
+          "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.1.9.tgz",
+          "integrity": "sha512-sY2RsIJ5rpER1u3/aQ8OFSI7qGIy8o1NEEbgb2UaJcvOtXOMpd39ko723NBpjQFg9SIX7TXtjejZVGeIMLhoOw==",
+          "dev": true,
+          "requires": {
+            "@babel/parser": "^7.1.0",
+            "@babel/types": "^7.0.0",
+            "@types/babel__generator": "*",
+            "@types/babel__template": "*",
+            "@types/babel__traverse": "*"
+          }
+        },
+        "@types/istanbul-reports": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-3.0.0.tgz",
+          "integrity": "sha512-nwKNbvnwJ2/mndE9ItP/zc2TCzw6uuodnF4EHYWD+gCQDVBuRQL5UzbZD0/ezy1iKsFU2ZQiDqg4M9dN4+wZgA==",
+          "dev": true,
+          "requires": {
+            "@types/istanbul-lib-report": "*"
+          }
+        },
+        "@types/yargs": {
+          "version": "15.0.5",
+          "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.5.tgz",
+          "integrity": "sha512-Dk/IDOPtOgubt/IaevIUbTgV7doaKkoorvOyYM2CMwuDyP89bekI7H4xLIwunNYiK9jhCkmc6pUrJk3cj2AB9w==",
+          "dev": true,
+          "requires": {
+            "@types/yargs-parser": "*"
+          }
+        },
+        "acorn": {
+          "version": "7.4.0",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.0.tgz",
+          "integrity": "sha512-+G7P8jJmCHr+S+cLfQxygbWhXy+8YTVGzAkpEbcLo2mLoL7tij/VG41QSHACSf5QgYRhMZYHuNc6drJaO0Da+w==",
+          "dev": true
+        },
+        "acorn-globals": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-6.0.0.tgz",
+          "integrity": "sha512-ZQl7LOWaF5ePqqcX4hLuv/bLXYQNfNWw2c0/yX/TsPRKamzHcTGQnlCjHT3TsmkOUVEPS3crCxiPfdzE/Trlhg==",
+          "dev": true,
+          "requires": {
+            "acorn": "^7.1.1",
+            "acorn-walk": "^7.1.1"
+          }
+        },
+        "acorn-walk": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-7.2.0.tgz",
+          "integrity": "sha512-OPdCF6GsMIP+Az+aWfAAOEt2/+iVDKE7oy6lJ098aoe59oAmK76qV6Gw60SbZ8jHuG2wH058GF4pLFbYamYrVA==",
+          "dev": true
+        },
+        "ansi-escapes": {
+          "version": "4.3.1",
+          "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.1.tgz",
+          "integrity": "sha512-JWF7ocqNrp8u9oqpgV+wH5ftbt+cfvv+PTjOvKLT3AdYly/LmORARfEVT1iyjwN+4MqE5UmVKoAdIBqeoCHgLA==",
+          "dev": true,
+          "requires": {
+            "type-fest": "^0.11.0"
+          },
+          "dependencies": {
+            "type-fest": {
+              "version": "0.11.0",
+              "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.11.0.tgz",
+              "integrity": "sha512-OdjXJxnCN1AvyLSzeKIgXTXxV+99ZuXl3Hpo9XpJAv9MBcHrrJOQ5kV7ypXOuQie+AmWG25hLbiKdwYTifzcfQ==",
+              "dev": true
+            }
+          }
+        },
+        "ansi-regex": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
+          "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+          "dev": true
+        },
+        "ansi-styles": {
+          "version": "4.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+          "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+          "dev": true,
+          "requires": {
+            "@types/color-name": "^1.1.1",
+            "color-convert": "^2.0.1"
+          }
+        },
+        "anymatch": {
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.1.tgz",
+          "integrity": "sha512-mM8522psRCqzV+6LhomX5wgp25YVibjh8Wj23I5RPkPppSVSjyKD2A2mBJmWGa+KN7f2D6LNh9jkBCeyLktzjg==",
+          "dev": true,
+          "requires": {
+            "normalize-path": "^3.0.0",
+            "picomatch": "^2.0.4"
+          }
+        },
+        "babel-jest": {
+          "version": "26.3.0",
+          "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-26.3.0.tgz",
+          "integrity": "sha512-sxPnQGEyHAOPF8NcUsD0g7hDCnvLL2XyblRBcgrzTWBB/mAIpWow3n1bEL+VghnnZfreLhFSBsFluRoK2tRK4g==",
+          "dev": true,
+          "requires": {
+            "@jest/transform": "^26.3.0",
+            "@jest/types": "^26.3.0",
+            "@types/babel__core": "^7.1.7",
+            "babel-plugin-istanbul": "^6.0.0",
+            "babel-preset-jest": "^26.3.0",
+            "chalk": "^4.0.0",
+            "graceful-fs": "^4.2.4",
+            "slash": "^3.0.0"
+          }
+        },
+        "babel-plugin-istanbul": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/babel-plugin-istanbul/-/babel-plugin-istanbul-6.0.0.tgz",
+          "integrity": "sha512-AF55rZXpe7trmEylbaE1Gv54wn6rwU03aptvRoVIGP8YykoSxqdVLV1TfwflBCE/QtHmqtP8SWlTENqbK8GCSQ==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-plugin-utils": "^7.0.0",
+            "@istanbuljs/load-nyc-config": "^1.0.0",
+            "@istanbuljs/schema": "^0.1.2",
+            "istanbul-lib-instrument": "^4.0.0",
+            "test-exclude": "^6.0.0"
+          }
+        },
+        "babel-plugin-jest-hoist": {
+          "version": "26.2.0",
+          "resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-26.2.0.tgz",
+          "integrity": "sha512-B/hVMRv8Nh1sQ1a3EY8I0n4Y1Wty3NrR5ebOyVT302op+DOAau+xNEImGMsUWOC3++ZlMooCytKz+NgN8aKGbA==",
+          "dev": true,
+          "requires": {
+            "@babel/template": "^7.3.3",
+            "@babel/types": "^7.3.3",
+            "@types/babel__core": "^7.0.0",
+            "@types/babel__traverse": "^7.0.6"
+          }
+        },
+        "babel-preset-jest": {
+          "version": "26.3.0",
+          "resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-26.3.0.tgz",
+          "integrity": "sha512-5WPdf7nyYi2/eRxCbVrE1kKCWxgWY4RsPEbdJWFm7QsesFGqjdkyLeu1zRkwM1cxK6EPIlNd6d2AxLk7J+t4pw==",
+          "dev": true,
+          "requires": {
+            "babel-plugin-jest-hoist": "^26.2.0",
+            "babel-preset-current-node-syntax": "^0.1.3"
+          }
+        },
+        "braces": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
+          "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+          "dev": true,
+          "requires": {
+            "fill-range": "^7.0.1"
+          }
+        },
+        "callsites": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
+          "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
+          "dev": true
+        },
+        "camelcase": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.0.0.tgz",
+          "integrity": "sha512-8KMDF1Vz2gzOq54ONPJS65IvTUaB1cHJ2DMM7MbPmLZljDH1qpzzLsWdiN9pHh6qvkRVDTi/07+eNGch/oLU4w==",
+          "dev": true
+        },
+        "chalk": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
+          "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "cliui": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/cliui/-/cliui-6.0.0.tgz",
+          "integrity": "sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==",
+          "dev": true,
+          "requires": {
+            "string-width": "^4.2.0",
+            "strip-ansi": "^6.0.0",
+            "wrap-ansi": "^6.2.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        },
+        "cross-spawn": {
+          "version": "7.0.3",
+          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
+          "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+          "dev": true,
+          "requires": {
+            "path-key": "^3.1.0",
+            "shebang-command": "^2.0.0",
+            "which": "^2.0.1"
+          }
+        },
+        "cssom": {
+          "version": "0.4.4",
+          "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.4.4.tgz",
+          "integrity": "sha512-p3pvU7r1MyyqbTk+WbNJIgJjG2VmTIaB10rI93LzVPrmDJKkzKYMtxxyAvQXR/NS6otuzveI7+7BBq3SjBS2mw==",
+          "dev": true
+        },
+        "cssstyle": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-2.3.0.tgz",
+          "integrity": "sha512-AZL67abkUzIuvcHqk7c09cezpGNcxUxU4Ioi/05xHk4DQeTkWmGYftIE6ctU6AEt+Gn4n1lDStOtj7FKycP71A==",
+          "dev": true,
+          "requires": {
+            "cssom": "~0.3.6"
+          },
+          "dependencies": {
+            "cssom": {
+              "version": "0.3.8",
+              "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.3.8.tgz",
+              "integrity": "sha512-b0tGHbfegbhPJpxpiBPU2sCkigAqtM9O121le6bbOlgyV+NyGyCmVfJ6QW9eRjz8CpNfWEOYBIMIGRYkLwsIYg==",
+              "dev": true
+            }
+          }
+        },
+        "data-urls": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-2.0.0.tgz",
+          "integrity": "sha512-X5eWTSXO/BJmpdIKCRuKUgSCgAN0OwliVK3yPKbwIWU1Tdw5BRajxlzMidvh+gwko9AfQ9zIj52pzF91Q3YAvQ==",
+          "dev": true,
+          "requires": {
+            "abab": "^2.0.3",
+            "whatwg-mimetype": "^2.3.0",
+            "whatwg-url": "^8.0.0"
+          }
+        },
+        "debug": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+          "dev": true,
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "detect-newline": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-3.1.0.tgz",
+          "integrity": "sha512-TLz+x/vEXm/Y7P7wn1EJFNLxYpUD4TgMosxY6fAVJUnJMbupHBOncxyWUG9OpTaH9EBD7uFI5LfEgmMOc54DsA==",
+          "dev": true
+        },
+        "diff-sequences": {
+          "version": "26.3.0",
+          "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-26.3.0.tgz",
+          "integrity": "sha512-5j5vdRcw3CNctePNYN0Wy2e/JbWT6cAYnXv5OuqPhDpyCGc0uLu2TK0zOCJWNB9kOIfYMSpIulRaDgIi4HJ6Ig==",
+          "dev": true
+        },
+        "domexception": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/domexception/-/domexception-2.0.1.tgz",
+          "integrity": "sha512-yxJ2mFy/sibVQlu5qHjOkf9J3K6zgmCxgJ94u2EdvDOV09H+32LtRswEcUsmUWN72pVLOEnTSRaIVVzVQgS0dg==",
+          "dev": true,
+          "requires": {
+            "webidl-conversions": "^5.0.0"
+          },
+          "dependencies": {
+            "webidl-conversions": {
+              "version": "5.0.0",
+              "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-5.0.0.tgz",
+              "integrity": "sha512-VlZwKPCkYKxQgeSbH5EyngOmRp7Ww7I9rQLERETtf5ofd9pGeswWiOtogpEO850jziPRarreGxn5QIiTqpb2wA==",
+              "dev": true
+            }
+          }
+        },
+        "emoji-regex": {
+          "version": "8.0.0",
+          "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+          "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+          "dev": true
+        },
+        "escape-string-regexp": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz",
+          "integrity": "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==",
+          "dev": true
+        },
+        "execa": {
+          "version": "4.0.3",
+          "resolved": "https://registry.npmjs.org/execa/-/execa-4.0.3.tgz",
+          "integrity": "sha512-WFDXGHckXPWZX19t1kCsXzOpqX9LWYNqn4C+HqZlk/V0imTkzJZqf87ZBhvpHaftERYknpk0fjSylnXVlVgI0A==",
+          "dev": true,
+          "requires": {
+            "cross-spawn": "^7.0.0",
+            "get-stream": "^5.0.0",
+            "human-signals": "^1.1.1",
+            "is-stream": "^2.0.0",
+            "merge-stream": "^2.0.0",
+            "npm-run-path": "^4.0.0",
+            "onetime": "^5.1.0",
+            "signal-exit": "^3.0.2",
+            "strip-final-newline": "^2.0.0"
+          }
+        },
+        "expect": {
+          "version": "26.4.2",
+          "resolved": "https://registry.npmjs.org/expect/-/expect-26.4.2.tgz",
+          "integrity": "sha512-IlJ3X52Z0lDHm7gjEp+m76uX46ldH5VpqmU0006vqDju/285twh7zaWMRhs67VpQhBwjjMchk+p5aA0VkERCAA==",
+          "dev": true,
+          "requires": {
+            "@jest/types": "^26.3.0",
+            "ansi-styles": "^4.0.0",
+            "jest-get-type": "^26.3.0",
+            "jest-matcher-utils": "^26.4.2",
+            "jest-message-util": "^26.3.0",
+            "jest-regex-util": "^26.0.0"
+          }
+        },
+        "fill-range": {
+          "version": "7.0.1",
+          "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
+          "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+          "dev": true,
+          "requires": {
+            "to-regex-range": "^5.0.1"
+          }
+        },
+        "find-up": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+          "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+          "dev": true,
+          "requires": {
+            "locate-path": "^5.0.0",
+            "path-exists": "^4.0.0"
+          }
+        },
+        "fsevents": {
+          "version": "2.1.3",
+          "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.1.3.tgz",
+          "integrity": "sha512-Auw9a4AxqWpa9GUfj370BMPzzyncfBABW8Mab7BGWBYDj4Isgq+cDKtx0i6u9jcX9pQDnswsaaOTgTmA5pEjuQ==",
+          "dev": true,
+          "optional": true
+        },
+        "get-stream": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
+          "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
+          "dev": true,
+          "requires": {
+            "pump": "^3.0.0"
+          }
+        },
+        "graceful-fs": {
+          "version": "4.2.4",
+          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.4.tgz",
+          "integrity": "sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw==",
+          "dev": true
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "html-encoding-sniffer": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-2.0.1.tgz",
+          "integrity": "sha512-D5JbOMBIR/TVZkubHT+OyT2705QvogUW4IBn6nHd756OwieSF9aDYFj4dv6HHEVGYbHaLETa3WggZYWWMyy3ZQ==",
+          "dev": true,
+          "requires": {
+            "whatwg-encoding": "^1.0.5"
+          }
+        },
+        "import-local": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/import-local/-/import-local-3.0.2.tgz",
+          "integrity": "sha512-vjL3+w0oulAVZ0hBHnxa/Nm5TAurf9YLQJDhqRZyqb+VKGOB6LU8t9H1Nr5CIo16vh9XfJTOoHwU0B71S557gA==",
+          "dev": true,
+          "requires": {
+            "pkg-dir": "^4.2.0",
+            "resolve-cwd": "^3.0.0"
+          }
+        },
+        "is-fullwidth-code-point": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+          "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+          "dev": true
+        },
+        "is-number": {
+          "version": "7.0.0",
+          "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+          "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+          "dev": true
+        },
+        "is-stream": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.0.tgz",
+          "integrity": "sha512-XCoy+WlUr7d1+Z8GgSuXmpuUFC9fOhRXglJMx+dwLKTkL44Cjd4W1Z5P+BQZpr+cR93aGP4S/s7Ftw6Nd/kiEw==",
+          "dev": true
+        },
+        "is-wsl": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.2.0.tgz",
+          "integrity": "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "is-docker": "^2.0.0"
+          }
+        },
+        "istanbul-lib-coverage": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.0.0.tgz",
+          "integrity": "sha512-UiUIqxMgRDET6eR+o5HbfRYP1l0hqkWOs7vNxC/mggutCMUIhWMm8gAHb8tHlyfD3/l6rlgNA5cKdDzEAf6hEg==",
+          "dev": true
+        },
+        "istanbul-lib-instrument": {
+          "version": "4.0.3",
+          "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-4.0.3.tgz",
+          "integrity": "sha512-BXgQl9kf4WTCPCCpmFGoJkz/+uhvm7h7PFKUYxh7qarQd3ER33vHG//qaE8eN25l07YqZPpHXU9I09l/RD5aGQ==",
+          "dev": true,
+          "requires": {
+            "@babel/core": "^7.7.5",
+            "@istanbuljs/schema": "^0.1.2",
+            "istanbul-lib-coverage": "^3.0.0",
+            "semver": "^6.3.0"
+          },
+          "dependencies": {
+            "@babel/code-frame": {
+              "version": "7.10.4",
+              "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.10.4.tgz",
+              "integrity": "sha512-vG6SvB6oYEhvgisZNFRmRCUkLz11c7rp+tbNTynGqc6mS1d5ATd/sGyV6W0KZZnXRKMTzZDRgQT3Ou9jhpAfUg==",
+              "dev": true,
+              "requires": {
+                "@babel/highlight": "^7.10.4"
+              }
+            },
+            "@babel/core": {
+              "version": "7.11.6",
+              "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.11.6.tgz",
+              "integrity": "sha512-Wpcv03AGnmkgm6uS6k8iwhIwTrcP0m17TL1n1sy7qD0qelDu4XNeW0dN0mHfa+Gei211yDaLoEe/VlbXQzM4Bg==",
+              "dev": true,
+              "requires": {
+                "@babel/code-frame": "^7.10.4",
+                "@babel/generator": "^7.11.6",
+                "@babel/helper-module-transforms": "^7.11.0",
+                "@babel/helpers": "^7.10.4",
+                "@babel/parser": "^7.11.5",
+                "@babel/template": "^7.10.4",
+                "@babel/traverse": "^7.11.5",
+                "@babel/types": "^7.11.5",
+                "convert-source-map": "^1.7.0",
+                "debug": "^4.1.0",
+                "gensync": "^1.0.0-beta.1",
+                "json5": "^2.1.2",
+                "lodash": "^4.17.19",
+                "resolve": "^1.3.2",
+                "semver": "^5.4.1",
+                "source-map": "^0.5.0"
+              },
+              "dependencies": {
+                "semver": {
+                  "version": "5.7.1",
+                  "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+                  "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+                  "dev": true
+                }
+              }
+            },
+            "source-map": {
+              "version": "0.5.7",
+              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+              "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+              "dev": true
+            }
+          }
+        },
+        "istanbul-lib-report": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.0.tgz",
+          "integrity": "sha512-wcdi+uAKzfiGT2abPpKZ0hSU1rGQjUQnLvtY5MpQ7QCTahD3VODhcu4wcfY1YtkGaDD5yuydOLINXsfbus9ROw==",
+          "dev": true,
+          "requires": {
+            "istanbul-lib-coverage": "^3.0.0",
+            "make-dir": "^3.0.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "istanbul-lib-source-maps": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-4.0.0.tgz",
+          "integrity": "sha512-c16LpFRkR8vQXyHZ5nLpY35JZtzj1PQY1iZmesUbf1FZHbIupcWfjgOXBY9YHkLEQ6puz1u4Dgj6qmU/DisrZg==",
+          "dev": true,
+          "requires": {
+            "debug": "^4.1.1",
+            "istanbul-lib-coverage": "^3.0.0",
+            "source-map": "^0.6.1"
+          }
+        },
+        "istanbul-reports": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.0.2.tgz",
+          "integrity": "sha512-9tZvz7AiR3PEDNGiV9vIouQ/EAcqMXFmkcA1CDFTwOB98OZVDL0PH9glHotf5Ugp6GCOTypfzGWI/OqjWNCRUw==",
+          "dev": true,
+          "requires": {
+            "html-escaper": "^2.0.0",
+            "istanbul-lib-report": "^3.0.0"
+          }
+        },
+        "jest-changed-files": {
+          "version": "26.3.0",
+          "resolved": "https://registry.npmjs.org/jest-changed-files/-/jest-changed-files-26.3.0.tgz",
+          "integrity": "sha512-1C4R4nijgPltX6fugKxM4oQ18zimS7LqQ+zTTY8lMCMFPrxqBFb7KJH0Z2fRQJvw2Slbaipsqq7s1mgX5Iot+g==",
+          "dev": true,
+          "requires": {
+            "@jest/types": "^26.3.0",
+            "execa": "^4.0.0",
+            "throat": "^5.0.0"
+          }
+        },
+        "jest-cli": {
+          "version": "26.4.2",
+          "resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-26.4.2.tgz",
+          "integrity": "sha512-zb+lGd/SfrPvoRSC/0LWdaWCnscXc1mGYW//NP4/tmBvRPT3VntZ2jtKUONsRi59zc5JqmsSajA9ewJKFYp8Cw==",
+          "dev": true,
+          "requires": {
+            "@jest/core": "^26.4.2",
+            "@jest/test-result": "^26.3.0",
+            "@jest/types": "^26.3.0",
+            "chalk": "^4.0.0",
+            "exit": "^0.1.2",
+            "graceful-fs": "^4.2.4",
+            "import-local": "^3.0.2",
             "is-ci": "^2.0.0",
-            "jest-config": "^24.9.0",
-            "jest-util": "^24.9.0",
-            "jest-validate": "^24.9.0",
+            "jest-config": "^26.4.2",
+            "jest-util": "^26.3.0",
+            "jest-validate": "^26.4.2",
             "prompts": "^2.0.1",
-            "realpath-native": "^1.1.0",
-            "yargs": "^13.3.0"
+            "yargs": "^15.3.1"
+          }
+        },
+        "jest-config": {
+          "version": "26.4.2",
+          "resolved": "https://registry.npmjs.org/jest-config/-/jest-config-26.4.2.tgz",
+          "integrity": "sha512-QBf7YGLuToiM8PmTnJEdRxyYy3mHWLh24LJZKVdXZ2PNdizSe1B/E8bVm+HYcjbEzGuVXDv/di+EzdO/6Gq80A==",
+          "dev": true,
+          "requires": {
+            "@babel/core": "^7.1.0",
+            "@jest/test-sequencer": "^26.4.2",
+            "@jest/types": "^26.3.0",
+            "babel-jest": "^26.3.0",
+            "chalk": "^4.0.0",
+            "deepmerge": "^4.2.2",
+            "glob": "^7.1.1",
+            "graceful-fs": "^4.2.4",
+            "jest-environment-jsdom": "^26.3.0",
+            "jest-environment-node": "^26.3.0",
+            "jest-get-type": "^26.3.0",
+            "jest-jasmine2": "^26.4.2",
+            "jest-regex-util": "^26.0.0",
+            "jest-resolve": "^26.4.0",
+            "jest-util": "^26.3.0",
+            "jest-validate": "^26.4.2",
+            "micromatch": "^4.0.2",
+            "pretty-format": "^26.4.2"
+          }
+        },
+        "jest-diff": {
+          "version": "26.4.2",
+          "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-26.4.2.tgz",
+          "integrity": "sha512-6T1XQY8U28WH0Z5rGpQ+VqZSZz8EN8rZcBtfvXaOkbwxIEeRre6qnuZQlbY1AJ4MKDxQF8EkrCvK+hL/VkyYLQ==",
+          "dev": true,
+          "requires": {
+            "chalk": "^4.0.0",
+            "diff-sequences": "^26.3.0",
+            "jest-get-type": "^26.3.0",
+            "pretty-format": "^26.4.2"
+          }
+        },
+        "jest-docblock": {
+          "version": "26.0.0",
+          "resolved": "https://registry.npmjs.org/jest-docblock/-/jest-docblock-26.0.0.tgz",
+          "integrity": "sha512-RDZ4Iz3QbtRWycd8bUEPxQsTlYazfYn/h5R65Fc6gOfwozFhoImx+affzky/FFBuqISPTqjXomoIGJVKBWoo0w==",
+          "dev": true,
+          "requires": {
+            "detect-newline": "^3.0.0"
+          }
+        },
+        "jest-each": {
+          "version": "26.4.2",
+          "resolved": "https://registry.npmjs.org/jest-each/-/jest-each-26.4.2.tgz",
+          "integrity": "sha512-p15rt8r8cUcRY0Mvo1fpkOGYm7iI8S6ySxgIdfh3oOIv+gHwrHTy5VWCGOecWUhDsit4Nz8avJWdT07WLpbwDA==",
+          "dev": true,
+          "requires": {
+            "@jest/types": "^26.3.0",
+            "chalk": "^4.0.0",
+            "jest-get-type": "^26.3.0",
+            "jest-util": "^26.3.0",
+            "pretty-format": "^26.4.2"
+          }
+        },
+        "jest-environment-jsdom": {
+          "version": "26.3.0",
+          "resolved": "https://registry.npmjs.org/jest-environment-jsdom/-/jest-environment-jsdom-26.3.0.tgz",
+          "integrity": "sha512-zra8He2btIMJkAzvLaiZ9QwEPGEetbxqmjEBQwhH3CA+Hhhu0jSiEJxnJMbX28TGUvPLxBt/zyaTLrOPF4yMJA==",
+          "dev": true,
+          "requires": {
+            "@jest/environment": "^26.3.0",
+            "@jest/fake-timers": "^26.3.0",
+            "@jest/types": "^26.3.0",
+            "@types/node": "*",
+            "jest-mock": "^26.3.0",
+            "jest-util": "^26.3.0",
+            "jsdom": "^16.2.2"
+          }
+        },
+        "jest-environment-node": {
+          "version": "26.3.0",
+          "resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-26.3.0.tgz",
+          "integrity": "sha512-c9BvYoo+FGcMj5FunbBgtBnbR5qk3uky8PKyRVpSfe2/8+LrNQMiXX53z6q2kY+j15SkjQCOSL/6LHnCPLVHNw==",
+          "dev": true,
+          "requires": {
+            "@jest/environment": "^26.3.0",
+            "@jest/fake-timers": "^26.3.0",
+            "@jest/types": "^26.3.0",
+            "@types/node": "*",
+            "jest-mock": "^26.3.0",
+            "jest-util": "^26.3.0"
+          }
+        },
+        "jest-get-type": {
+          "version": "26.3.0",
+          "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-26.3.0.tgz",
+          "integrity": "sha512-TpfaviN1R2pQWkIihlfEanwOXK0zcxrKEE4MlU6Tn7keoXdN6/3gK/xl0yEh8DOunn5pOVGKf8hB4R9gVh04ig==",
+          "dev": true
+        },
+        "jest-haste-map": {
+          "version": "26.3.0",
+          "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-26.3.0.tgz",
+          "integrity": "sha512-DHWBpTJgJhLLGwE5Z1ZaqLTYqeODQIZpby0zMBsCU9iRFHYyhklYqP4EiG73j5dkbaAdSZhgB938mL51Q5LeZA==",
+          "dev": true,
+          "requires": {
+            "@jest/types": "^26.3.0",
+            "@types/graceful-fs": "^4.1.2",
+            "@types/node": "*",
+            "anymatch": "^3.0.3",
+            "fb-watchman": "^2.0.0",
+            "fsevents": "^2.1.2",
+            "graceful-fs": "^4.2.4",
+            "jest-regex-util": "^26.0.0",
+            "jest-serializer": "^26.3.0",
+            "jest-util": "^26.3.0",
+            "jest-worker": "^26.3.0",
+            "micromatch": "^4.0.2",
+            "sane": "^4.0.3",
+            "walker": "^1.0.7"
+          }
+        },
+        "jest-jasmine2": {
+          "version": "26.4.2",
+          "resolved": "https://registry.npmjs.org/jest-jasmine2/-/jest-jasmine2-26.4.2.tgz",
+          "integrity": "sha512-z7H4EpCldHN1J8fNgsja58QftxBSL+JcwZmaXIvV9WKIM+x49F4GLHu/+BQh2kzRKHAgaN/E82od+8rTOBPyPA==",
+          "dev": true,
+          "requires": {
+            "@babel/traverse": "^7.1.0",
+            "@jest/environment": "^26.3.0",
+            "@jest/source-map": "^26.3.0",
+            "@jest/test-result": "^26.3.0",
+            "@jest/types": "^26.3.0",
+            "@types/node": "*",
+            "chalk": "^4.0.0",
+            "co": "^4.6.0",
+            "expect": "^26.4.2",
+            "is-generator-fn": "^2.0.0",
+            "jest-each": "^26.4.2",
+            "jest-matcher-utils": "^26.4.2",
+            "jest-message-util": "^26.3.0",
+            "jest-runtime": "^26.4.2",
+            "jest-snapshot": "^26.4.2",
+            "jest-util": "^26.3.0",
+            "pretty-format": "^26.4.2",
+            "throat": "^5.0.0"
+          }
+        },
+        "jest-leak-detector": {
+          "version": "26.4.2",
+          "resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-26.4.2.tgz",
+          "integrity": "sha512-akzGcxwxtE+9ZJZRW+M2o+nTNnmQZxrHJxX/HjgDaU5+PLmY1qnQPnMjgADPGCRPhB+Yawe1iij0REe+k/aHoA==",
+          "dev": true,
+          "requires": {
+            "jest-get-type": "^26.3.0",
+            "pretty-format": "^26.4.2"
+          }
+        },
+        "jest-matcher-utils": {
+          "version": "26.4.2",
+          "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-26.4.2.tgz",
+          "integrity": "sha512-KcbNqWfWUG24R7tu9WcAOKKdiXiXCbMvQYT6iodZ9k1f7065k0keUOW6XpJMMvah+hTfqkhJhRXmA3r3zMAg0Q==",
+          "dev": true,
+          "requires": {
+            "chalk": "^4.0.0",
+            "jest-diff": "^26.4.2",
+            "jest-get-type": "^26.3.0",
+            "pretty-format": "^26.4.2"
+          }
+        },
+        "jest-message-util": {
+          "version": "26.3.0",
+          "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-26.3.0.tgz",
+          "integrity": "sha512-xIavRYqr4/otGOiLxLZGj3ieMmjcNE73Ui+LdSW/Y790j5acqCsAdDiLIbzHCZMpN07JOENRWX5DcU+OQ+TjTA==",
+          "dev": true,
+          "requires": {
+            "@babel/code-frame": "^7.0.0",
+            "@jest/types": "^26.3.0",
+            "@types/stack-utils": "^1.0.1",
+            "chalk": "^4.0.0",
+            "graceful-fs": "^4.2.4",
+            "micromatch": "^4.0.2",
+            "slash": "^3.0.0",
+            "stack-utils": "^2.0.2"
+          }
+        },
+        "jest-mock": {
+          "version": "26.3.0",
+          "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-26.3.0.tgz",
+          "integrity": "sha512-PeaRrg8Dc6mnS35gOo/CbZovoDPKAeB1FICZiuagAgGvbWdNNyjQjkOaGUa/3N3JtpQ/Mh9P4A2D4Fv51NnP8Q==",
+          "dev": true,
+          "requires": {
+            "@jest/types": "^26.3.0",
+            "@types/node": "*"
+          }
+        },
+        "jest-regex-util": {
+          "version": "26.0.0",
+          "resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-26.0.0.tgz",
+          "integrity": "sha512-Gv3ZIs/nA48/Zvjrl34bf+oD76JHiGDUxNOVgUjh3j890sblXryjY4rss71fPtD/njchl6PSE2hIhvyWa1eT0A==",
+          "dev": true
+        },
+        "jest-resolve": {
+          "version": "26.4.0",
+          "resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-26.4.0.tgz",
+          "integrity": "sha512-bn/JoZTEXRSlEx3+SfgZcJAVuTMOksYq9xe9O6s4Ekg84aKBObEaVXKOEilULRqviSLAYJldnoWV9c07kwtiCg==",
+          "dev": true,
+          "requires": {
+            "@jest/types": "^26.3.0",
+            "chalk": "^4.0.0",
+            "graceful-fs": "^4.2.4",
+            "jest-pnp-resolver": "^1.2.2",
+            "jest-util": "^26.3.0",
+            "read-pkg-up": "^7.0.1",
+            "resolve": "^1.17.0",
+            "slash": "^3.0.0"
+          },
+          "dependencies": {
+            "resolve": {
+              "version": "1.17.0",
+              "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.17.0.tgz",
+              "integrity": "sha512-ic+7JYiV8Vi2yzQGFWOkiZD5Z9z7O2Zhm9XMaTxdJExKasieFCr+yXZ/WmXsckHiKl12ar0y6XiXDx3m4RHn1w==",
+              "dev": true,
+              "requires": {
+                "path-parse": "^1.0.6"
+              }
+            }
+          }
+        },
+        "jest-resolve-dependencies": {
+          "version": "26.4.2",
+          "resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-26.4.2.tgz",
+          "integrity": "sha512-ADHaOwqEcVc71uTfySzSowA/RdxUpCxhxa2FNLiin9vWLB1uLPad3we+JSSROq5+SrL9iYPdZZF8bdKM7XABTQ==",
+          "dev": true,
+          "requires": {
+            "@jest/types": "^26.3.0",
+            "jest-regex-util": "^26.0.0",
+            "jest-snapshot": "^26.4.2"
+          }
+        },
+        "jest-runner": {
+          "version": "26.4.2",
+          "resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-26.4.2.tgz",
+          "integrity": "sha512-FgjDHeVknDjw1gRAYaoUoShe1K3XUuFMkIaXbdhEys+1O4bEJS8Avmn4lBwoMfL8O5oFTdWYKcf3tEJyyYyk8g==",
+          "dev": true,
+          "requires": {
+            "@jest/console": "^26.3.0",
+            "@jest/environment": "^26.3.0",
+            "@jest/test-result": "^26.3.0",
+            "@jest/types": "^26.3.0",
+            "@types/node": "*",
+            "chalk": "^4.0.0",
+            "emittery": "^0.7.1",
+            "exit": "^0.1.2",
+            "graceful-fs": "^4.2.4",
+            "jest-config": "^26.4.2",
+            "jest-docblock": "^26.0.0",
+            "jest-haste-map": "^26.3.0",
+            "jest-leak-detector": "^26.4.2",
+            "jest-message-util": "^26.3.0",
+            "jest-resolve": "^26.4.0",
+            "jest-runtime": "^26.4.2",
+            "jest-util": "^26.3.0",
+            "jest-worker": "^26.3.0",
+            "source-map-support": "^0.5.6",
+            "throat": "^5.0.0"
+          }
+        },
+        "jest-runtime": {
+          "version": "26.4.2",
+          "resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-26.4.2.tgz",
+          "integrity": "sha512-4Pe7Uk5a80FnbHwSOk7ojNCJvz3Ks2CNQWT5Z7MJo4tX0jb3V/LThKvD9tKPNVNyeMH98J/nzGlcwc00R2dSHQ==",
+          "dev": true,
+          "requires": {
+            "@jest/console": "^26.3.0",
+            "@jest/environment": "^26.3.0",
+            "@jest/fake-timers": "^26.3.0",
+            "@jest/globals": "^26.4.2",
+            "@jest/source-map": "^26.3.0",
+            "@jest/test-result": "^26.3.0",
+            "@jest/transform": "^26.3.0",
+            "@jest/types": "^26.3.0",
+            "@types/yargs": "^15.0.0",
+            "chalk": "^4.0.0",
+            "collect-v8-coverage": "^1.0.0",
+            "exit": "^0.1.2",
+            "glob": "^7.1.3",
+            "graceful-fs": "^4.2.4",
+            "jest-config": "^26.4.2",
+            "jest-haste-map": "^26.3.0",
+            "jest-message-util": "^26.3.0",
+            "jest-mock": "^26.3.0",
+            "jest-regex-util": "^26.0.0",
+            "jest-resolve": "^26.4.0",
+            "jest-snapshot": "^26.4.2",
+            "jest-util": "^26.3.0",
+            "jest-validate": "^26.4.2",
+            "slash": "^3.0.0",
+            "strip-bom": "^4.0.0",
+            "yargs": "^15.3.1"
+          }
+        },
+        "jest-serializer": {
+          "version": "26.3.0",
+          "resolved": "https://registry.npmjs.org/jest-serializer/-/jest-serializer-26.3.0.tgz",
+          "integrity": "sha512-IDRBQBLPlKa4flg77fqg0n/pH87tcRKwe8zxOVTWISxGpPHYkRZ1dXKyh04JOja7gppc60+soKVZ791mruVdow==",
+          "dev": true,
+          "requires": {
+            "@types/node": "*",
+            "graceful-fs": "^4.2.4"
+          }
+        },
+        "jest-snapshot": {
+          "version": "26.4.2",
+          "resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-26.4.2.tgz",
+          "integrity": "sha512-N6Uub8FccKlf5SBFnL2Ri/xofbaA68Cc3MGjP/NuwgnsvWh+9hLIR/DhrxbSiKXMY9vUW5dI6EW1eHaDHqe9sg==",
+          "dev": true,
+          "requires": {
+            "@babel/types": "^7.0.0",
+            "@jest/types": "^26.3.0",
+            "@types/prettier": "^2.0.0",
+            "chalk": "^4.0.0",
+            "expect": "^26.4.2",
+            "graceful-fs": "^4.2.4",
+            "jest-diff": "^26.4.2",
+            "jest-get-type": "^26.3.0",
+            "jest-haste-map": "^26.3.0",
+            "jest-matcher-utils": "^26.4.2",
+            "jest-message-util": "^26.3.0",
+            "jest-resolve": "^26.4.0",
+            "natural-compare": "^1.4.0",
+            "pretty-format": "^26.4.2",
+            "semver": "^7.3.2"
+          },
+          "dependencies": {
+            "semver": {
+              "version": "7.3.2",
+              "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.2.tgz",
+              "integrity": "sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ==",
+              "dev": true
+            }
+          }
+        },
+        "jest-util": {
+          "version": "26.3.0",
+          "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-26.3.0.tgz",
+          "integrity": "sha512-4zpn6bwV0+AMFN0IYhH/wnzIQzRaYVrz1A8sYnRnj4UXDXbOVtWmlaZkO9mipFqZ13okIfN87aDoJWB7VH6hcw==",
+          "dev": true,
+          "requires": {
+            "@jest/types": "^26.3.0",
+            "@types/node": "*",
+            "chalk": "^4.0.0",
+            "graceful-fs": "^4.2.4",
+            "is-ci": "^2.0.0",
+            "micromatch": "^4.0.2"
+          }
+        },
+        "jest-validate": {
+          "version": "26.4.2",
+          "resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-26.4.2.tgz",
+          "integrity": "sha512-blft+xDX7XXghfhY0mrsBCYhX365n8K5wNDC4XAcNKqqjEzsRUSXP44m6PL0QJEW2crxQFLLztVnJ4j7oPlQrQ==",
+          "dev": true,
+          "requires": {
+            "@jest/types": "^26.3.0",
+            "camelcase": "^6.0.0",
+            "chalk": "^4.0.0",
+            "jest-get-type": "^26.3.0",
+            "leven": "^3.1.0",
+            "pretty-format": "^26.4.2"
+          }
+        },
+        "jest-watcher": {
+          "version": "26.3.0",
+          "resolved": "https://registry.npmjs.org/jest-watcher/-/jest-watcher-26.3.0.tgz",
+          "integrity": "sha512-XnLdKmyCGJ3VoF6G/p5ohbJ04q/vv5aH9ENI+i6BL0uu9WWB6Z7Z2lhQQk0d2AVZcRGp1yW+/TsoToMhBFPRdQ==",
+          "dev": true,
+          "requires": {
+            "@jest/test-result": "^26.3.0",
+            "@jest/types": "^26.3.0",
+            "@types/node": "*",
+            "ansi-escapes": "^4.2.1",
+            "chalk": "^4.0.0",
+            "jest-util": "^26.3.0",
+            "string-length": "^4.0.1"
+          }
+        },
+        "jest-worker": {
+          "version": "26.3.0",
+          "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-26.3.0.tgz",
+          "integrity": "sha512-Vmpn2F6IASefL+DVBhPzI2J9/GJUsqzomdeN+P+dK8/jKxbh8R3BtFnx3FIta7wYlPU62cpJMJQo4kuOowcMnw==",
+          "dev": true,
+          "requires": {
+            "@types/node": "*",
+            "merge-stream": "^2.0.0",
+            "supports-color": "^7.0.0"
+          }
+        },
+        "jsdom": {
+          "version": "16.4.0",
+          "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-16.4.0.tgz",
+          "integrity": "sha512-lYMm3wYdgPhrl7pDcRmvzPhhrGVBeVhPIqeHjzeiHN3DFmD1RBpbExbi8vU7BJdH8VAZYovR8DMt0PNNDM7k8w==",
+          "dev": true,
+          "requires": {
+            "abab": "^2.0.3",
+            "acorn": "^7.1.1",
+            "acorn-globals": "^6.0.0",
+            "cssom": "^0.4.4",
+            "cssstyle": "^2.2.0",
+            "data-urls": "^2.0.0",
+            "decimal.js": "^10.2.0",
+            "domexception": "^2.0.1",
+            "escodegen": "^1.14.1",
+            "html-encoding-sniffer": "^2.0.1",
+            "is-potential-custom-element-name": "^1.0.0",
+            "nwsapi": "^2.2.0",
+            "parse5": "5.1.1",
+            "request": "^2.88.2",
+            "request-promise-native": "^1.0.8",
+            "saxes": "^5.0.0",
+            "symbol-tree": "^3.2.4",
+            "tough-cookie": "^3.0.1",
+            "w3c-hr-time": "^1.0.2",
+            "w3c-xmlserializer": "^2.0.0",
+            "webidl-conversions": "^6.1.0",
+            "whatwg-encoding": "^1.0.5",
+            "whatwg-mimetype": "^2.3.0",
+            "whatwg-url": "^8.0.0",
+            "ws": "^7.2.3",
+            "xml-name-validator": "^3.0.0"
+          }
+        },
+        "json5": {
+          "version": "2.1.3",
+          "resolved": "https://registry.npmjs.org/json5/-/json5-2.1.3.tgz",
+          "integrity": "sha512-KXPvOm8K9IJKFM0bmdn8QXh7udDh1g/giieX0NLCaMnb4hEiVFqnop2ImTXCc5e0/oHz3LTqmHGtExn5hfMkOA==",
+          "dev": true,
+          "requires": {
+            "minimist": "^1.2.5"
+          }
+        },
+        "locate-path": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+          "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+          "dev": true,
+          "requires": {
+            "p-locate": "^4.1.0"
+          }
+        },
+        "lodash": {
+          "version": "4.17.20",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+          "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
+          "dev": true
+        },
+        "make-dir": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
+          "integrity": "sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==",
+          "dev": true,
+          "requires": {
+            "semver": "^6.0.0"
+          }
+        },
+        "micromatch": {
+          "version": "4.0.2",
+          "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.2.tgz",
+          "integrity": "sha512-y7FpHSbMUMoyPbYUSzO6PaZ6FyRnQOpHuKwbo1G+Knck95XVU4QAiKdGEnj5wwoS7PlOgthX/09u5iFJ+aYf5Q==",
+          "dev": true,
+          "requires": {
+            "braces": "^3.0.1",
+            "picomatch": "^2.0.5"
+          }
+        },
+        "minimist": {
+          "version": "1.2.5",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+          "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+          "dev": true
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+          "dev": true
+        },
+        "node-notifier": {
+          "version": "8.0.0",
+          "resolved": "https://registry.npmjs.org/node-notifier/-/node-notifier-8.0.0.tgz",
+          "integrity": "sha512-46z7DUmcjoYdaWyXouuFNNfUo6eFa94t23c53c+lG/9Cvauk4a98rAUp9672X5dxGdQmLpPzTxzu8f/OeEPaFA==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "growly": "^1.3.0",
+            "is-wsl": "^2.2.0",
+            "semver": "^7.3.2",
+            "shellwords": "^0.1.1",
+            "uuid": "^8.3.0",
+            "which": "^2.0.2"
+          },
+          "dependencies": {
+            "semver": {
+              "version": "7.3.2",
+              "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.2.tgz",
+              "integrity": "sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ==",
+              "dev": true,
+              "optional": true
+            }
+          }
+        },
+        "npm-run-path": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
+          "integrity": "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==",
+          "dev": true,
+          "requires": {
+            "path-key": "^3.0.0"
+          }
+        },
+        "p-each-series": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/p-each-series/-/p-each-series-2.1.0.tgz",
+          "integrity": "sha512-ZuRs1miPT4HrjFa+9fRfOFXxGJfORgelKV9f9nNOWw2gl6gVsRaVDOQP0+MI0G0wGKns1Yacsu0GjOFbTK0JFQ==",
+          "dev": true
+        },
+        "p-locate": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+          "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+          "dev": true,
+          "requires": {
+            "p-limit": "^2.2.0"
+          }
+        },
+        "parse-json": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.1.0.tgz",
+          "integrity": "sha512-+mi/lmVVNKFNVyLXV31ERiy2CY5E1/F6QtJFEzoChPRwwngMNXRDQ9GJ5WdE2Z2P4AujsOi0/+2qHID68KwfIQ==",
+          "dev": true,
+          "requires": {
+            "@babel/code-frame": "^7.0.0",
+            "error-ex": "^1.3.1",
+            "json-parse-even-better-errors": "^2.3.0",
+            "lines-and-columns": "^1.1.6"
+          }
+        },
+        "parse5": {
+          "version": "5.1.1",
+          "resolved": "https://registry.npmjs.org/parse5/-/parse5-5.1.1.tgz",
+          "integrity": "sha512-ugq4DFI0Ptb+WWjAdOK16+u/nHfiIrcE+sh8kZMaM0WllQKLI9rOUq6c2b7cwPkXdzfQESqvoqK6ug7U/Yyzug==",
+          "dev": true
+        },
+        "path-exists": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+          "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+          "dev": true
+        },
+        "path-key": {
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+          "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+          "dev": true
+        },
+        "pkg-dir": {
+          "version": "4.2.0",
+          "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-4.2.0.tgz",
+          "integrity": "sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==",
+          "dev": true,
+          "requires": {
+            "find-up": "^4.0.0"
+          }
+        },
+        "pretty-format": {
+          "version": "26.4.2",
+          "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-26.4.2.tgz",
+          "integrity": "sha512-zK6Gd8zDsEiVydOCGLkoBoZuqv8VTiHyAbKznXe/gaph/DAeZOmit9yMfgIz5adIgAMMs5XfoYSwAX3jcCO1tA==",
+          "dev": true,
+          "requires": {
+            "@jest/types": "^26.3.0",
+            "ansi-regex": "^5.0.0",
+            "ansi-styles": "^4.0.0",
+            "react-is": "^16.12.0"
+          }
+        },
+        "read-pkg": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-5.2.0.tgz",
+          "integrity": "sha512-Ug69mNOpfvKDAc2Q8DRpMjjzdtrnv9HcSMX+4VsZxD1aZ6ZzrIE7rlzXBtWTyhULSMKg076AW6WR5iZpD0JiOg==",
+          "dev": true,
+          "requires": {
+            "@types/normalize-package-data": "^2.4.0",
+            "normalize-package-data": "^2.5.0",
+            "parse-json": "^5.0.0",
+            "type-fest": "^0.6.0"
+          },
+          "dependencies": {
+            "type-fest": {
+              "version": "0.6.0",
+              "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.6.0.tgz",
+              "integrity": "sha512-q+MB8nYR1KDLrgr4G5yemftpMC7/QLqVndBmEEdqzmNj5dcFOO4Oo8qlwZE3ULT3+Zim1F8Kq4cBnikNhlCMlg==",
+              "dev": true
+            }
+          }
+        },
+        "read-pkg-up": {
+          "version": "7.0.1",
+          "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-7.0.1.tgz",
+          "integrity": "sha512-zK0TB7Xd6JpCLmlLmufqykGE+/TlOePD6qKClNW7hHDKFh/J7/7gCWGR7joEQEW1bKq3a3yUZSObOoWLFQ4ohg==",
+          "dev": true,
+          "requires": {
+            "find-up": "^4.1.0",
+            "read-pkg": "^5.2.0",
+            "type-fest": "^0.8.1"
+          }
+        },
+        "request": {
+          "version": "2.88.2",
+          "resolved": "https://registry.npmjs.org/request/-/request-2.88.2.tgz",
+          "integrity": "sha512-MsvtOrfG9ZcrOwAW+Qi+F6HbD0CWXEh9ou77uOb7FM2WPhwT7smM833PzanhJLsgXjN89Ir6V2PczXNnMpwKhw==",
+          "dev": true,
+          "requires": {
+            "aws-sign2": "~0.7.0",
+            "aws4": "^1.8.0",
+            "caseless": "~0.12.0",
+            "combined-stream": "~1.0.6",
+            "extend": "~3.0.2",
+            "forever-agent": "~0.6.1",
+            "form-data": "~2.3.2",
+            "har-validator": "~5.1.3",
+            "http-signature": "~1.2.0",
+            "is-typedarray": "~1.0.0",
+            "isstream": "~0.1.2",
+            "json-stringify-safe": "~5.0.1",
+            "mime-types": "~2.1.19",
+            "oauth-sign": "~0.9.0",
+            "performance-now": "^2.1.0",
+            "qs": "~6.5.2",
+            "safe-buffer": "^5.1.2",
+            "tough-cookie": "~2.5.0",
+            "tunnel-agent": "^0.6.0",
+            "uuid": "^3.3.2"
+          },
+          "dependencies": {
+            "tough-cookie": {
+              "version": "2.5.0",
+              "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.5.0.tgz",
+              "integrity": "sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==",
+              "dev": true,
+              "requires": {
+                "psl": "^1.1.28",
+                "punycode": "^2.1.1"
+              }
+            },
+            "uuid": {
+              "version": "3.4.0",
+              "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+              "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
+              "dev": true
+            }
+          }
+        },
+        "resolve-cwd": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/resolve-cwd/-/resolve-cwd-3.0.0.tgz",
+          "integrity": "sha512-OrZaX2Mb+rJCpH/6CpSqt9xFVpN++x01XnN2ie9g6P5/3xelLAkXWVADpdz1IHD/KFfEXyE6V0U01OQ3UO2rEg==",
+          "dev": true,
+          "requires": {
+            "resolve-from": "^5.0.0"
+          }
+        },
+        "resolve-from": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
+          "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
+          "dev": true
+        },
+        "rimraf": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+          "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+          "dev": true,
+          "requires": {
+            "glob": "^7.1.3"
+          }
+        },
+        "semver": {
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+          "dev": true
+        },
+        "shebang-command": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+          "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+          "dev": true,
+          "requires": {
+            "shebang-regex": "^3.0.0"
+          }
+        },
+        "shebang-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+          "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+          "dev": true
+        },
+        "slash": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
+          "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
+          "dev": true
+        },
+        "stack-utils": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-2.0.2.tgz",
+          "integrity": "sha512-0H7QK2ECz3fyZMzQ8rH0j2ykpfbnd20BFtfg/SqVC2+sCTtcw0aDTGB7dk+de4U4uUeuz6nOtJcrkFFLG1B0Rg==",
+          "dev": true,
+          "requires": {
+            "escape-string-regexp": "^2.0.0"
+          }
+        },
+        "string-length": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/string-length/-/string-length-4.0.1.tgz",
+          "integrity": "sha512-PKyXUd0LK0ePjSOnWn34V2uD6acUWev9uy0Ft05k0E8xRW+SKcA0F7eMr7h5xlzfn+4O3N+55rduYyet3Jk+jw==",
+          "dev": true,
+          "requires": {
+            "char-regex": "^1.0.2",
+            "strip-ansi": "^6.0.0"
+          }
+        },
+        "string-width": {
+          "version": "4.2.0",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.0.tgz",
+          "integrity": "sha512-zUz5JD+tgqtuDjMhwIg5uFVV3dtqZ9yQJlZVfq4I01/K5Paj5UHj7VyrQOJvzawSVlKpObApbfD0Ed6yJc+1eg==",
+          "dev": true,
+          "requires": {
+            "emoji-regex": "^8.0.0",
+            "is-fullwidth-code-point": "^3.0.0",
+            "strip-ansi": "^6.0.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
+          "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^5.0.0"
+          }
+        },
+        "strip-bom": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-4.0.0.tgz",
+          "integrity": "sha512-3xurFv5tEgii33Zi8Jtp55wEIILR9eh34FAW00PZf+JnSsTmV/ioewSgQl97JHvgjoRGwPShsWm+IdrxB35d0w==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        },
+        "test-exclude": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-6.0.0.tgz",
+          "integrity": "sha512-cAGWPIyOHU6zlmg88jwm7VRyXnMN7iV68OGAbYDk/Mh/xC/pzVPlQtY6ngoIH/5/tciuhGfvESU8GrHrcxD56w==",
+          "dev": true,
+          "requires": {
+            "@istanbuljs/schema": "^0.1.2",
+            "glob": "^7.1.4",
+            "minimatch": "^3.0.4"
+          }
+        },
+        "throat": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/throat/-/throat-5.0.0.tgz",
+          "integrity": "sha512-fcwX4mndzpLQKBS1DVYhGAcYaYt7vsHNIvQV+WXMvnow5cgjPphq5CaayLaGsjRdSCKZFNGt7/GYAuXaNOiYCA==",
+          "dev": true
+        },
+        "to-regex-range": {
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+          "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+          "dev": true,
+          "requires": {
+            "is-number": "^7.0.0"
+          }
+        },
+        "tough-cookie": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-3.0.1.tgz",
+          "integrity": "sha512-yQyJ0u4pZsv9D4clxO69OEjLWYw+jbgspjTue4lTQZLfV0c5l1VmK2y1JK8E9ahdpltPOaAThPcp5nKPUgSnsg==",
+          "dev": true,
+          "requires": {
+            "ip-regex": "^2.1.0",
+            "psl": "^1.1.28",
+            "punycode": "^2.1.1"
+          }
+        },
+        "tr46": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/tr46/-/tr46-2.0.2.tgz",
+          "integrity": "sha512-3n1qG+/5kg+jrbTzwAykB5yRYtQCTqOGKq5U5PE3b0a1/mzo6snDhjGS0zJVJunO0NrT3Dg1MLy5TjWP/UJppg==",
+          "dev": true,
+          "requires": {
+            "punycode": "^2.1.1"
+          }
+        },
+        "type-fest": {
+          "version": "0.8.1",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz",
+          "integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==",
+          "dev": true
+        },
+        "webidl-conversions": {
+          "version": "6.1.0",
+          "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-6.1.0.tgz",
+          "integrity": "sha512-qBIvFLGiBpLjfwmYAaHPXsn+ho5xZnGvyGvsarywGNc8VyQJUMHJ8OBKGGrPER0okBeMDaan4mNBlgBROxuI8w==",
+          "dev": true
+        },
+        "whatwg-url": {
+          "version": "8.2.2",
+          "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-8.2.2.tgz",
+          "integrity": "sha512-PcVnO6NiewhkmzV0qn7A+UZ9Xx4maNTI+O+TShmfE4pqjoCMwUMjkvoNhNHPTvgR7QH9Xt3R13iHuWy2sToFxQ==",
+          "dev": true,
+          "requires": {
+            "lodash.sortby": "^4.7.0",
+            "tr46": "^2.0.2",
+            "webidl-conversions": "^6.1.0"
+          }
+        },
+        "which": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+          "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+          "dev": true,
+          "requires": {
+            "isexe": "^2.0.0"
+          }
+        },
+        "wrap-ansi": {
+          "version": "6.2.0",
+          "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
+          "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.0.0",
+            "string-width": "^4.1.0",
+            "strip-ansi": "^6.0.0"
+          }
+        },
+        "write-file-atomic": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-3.0.3.tgz",
+          "integrity": "sha512-AvHcyZ5JnSfq3ioSyjrBkH9yW4m7Ayk8/9My/DD9onKeu/94fwrMocemO2QAJFAlnnDN+ZDS+ZjAR5ua1/PV/Q==",
+          "dev": true,
+          "requires": {
+            "imurmurhash": "^0.1.4",
+            "is-typedarray": "^1.0.0",
+            "signal-exit": "^3.0.2",
+            "typedarray-to-buffer": "^3.1.5"
+          }
+        },
+        "ws": {
+          "version": "7.3.1",
+          "resolved": "https://registry.npmjs.org/ws/-/ws-7.3.1.tgz",
+          "integrity": "sha512-D3RuNkynyHmEJIpD2qrgVkc9DQ23OrN/moAwZX4L8DfvszsJxpjQuUq3LMx6HoYji9fbIOBY18XWBsAux1ZZUA==",
+          "dev": true
+        },
+        "yargs": {
+          "version": "15.4.1",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-15.4.1.tgz",
+          "integrity": "sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==",
+          "dev": true,
+          "requires": {
+            "cliui": "^6.0.0",
+            "decamelize": "^1.2.0",
+            "find-up": "^4.1.0",
+            "get-caller-file": "^2.0.1",
+            "require-directory": "^2.1.1",
+            "require-main-filename": "^2.0.0",
+            "set-blocking": "^2.0.0",
+            "string-width": "^4.2.0",
+            "which-module": "^2.0.0",
+            "y18n": "^4.0.0",
+            "yargs-parser": "^18.1.2"
+          }
+        },
+        "yargs-parser": {
+          "version": "18.1.3",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.3.tgz",
+          "integrity": "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==",
+          "dev": true,
+          "requires": {
+            "camelcase": "^5.0.0",
+            "decamelize": "^1.2.0"
+          },
+          "dependencies": {
+            "camelcase": {
+              "version": "5.3.1",
+              "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+              "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+              "dev": true
+            }
           }
         }
       }
@@ -12005,9 +14807,9 @@
       }
     },
     "jest-pnp-resolver": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/jest-pnp-resolver/-/jest-pnp-resolver-1.2.1.tgz",
-      "integrity": "sha512-pgFw2tm54fzgYvc/OHrnysABEObZCUNFnhjoRjaVOCN8NYc032/gVjPaHD4Aq6ApkSieWtfKAFQtmDKAmhupnQ==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/jest-pnp-resolver/-/jest-pnp-resolver-1.2.2.tgz",
+      "integrity": "sha512-olV41bKSMm8BdnuMsewT4jqlZ8+3TCARAXjZGT9jcoSnrfUnRCqnMoF9XEeoWjbzObpqF9dRhHQj0Xb9QdF6/w==",
       "dev": true
     },
     "jest-regex-util": {
@@ -12284,9 +15086,9 @@
       },
       "dependencies": {
         "acorn": {
-          "version": "5.7.3",
-          "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.7.3.tgz",
-          "integrity": "sha512-T/zvzYRfbVojPWahDsE5evJdHb3oJoQfFbsrKM7w5Zcs++Tr257tia3BmMP8XYVjp1S9RZXQMh7gao96BlqZOw==",
+          "version": "5.7.4",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.7.4.tgz",
+          "integrity": "sha512-1D++VG7BhrtvQpNbBzovKNc1FLGGEE/oGe7b9xJm/RFHMBeUaUGpluV9RLjZa47YFdPcDAenEYuq9pQPcMdLJg==",
           "dev": true
         },
         "parse5": {
@@ -12313,6 +15115,12 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
       "integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==",
+      "dev": true
+    },
+    "json-parse-even-better-errors": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
+      "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
       "dev": true
     },
     "json-schema": {
@@ -12555,6 +15363,12 @@
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/lodash.difference/-/lodash.difference-4.5.0.tgz",
       "integrity": "sha1-nMtOUF1Ia5FlE0V3KIWi3yf9AXw=",
+      "dev": true
+    },
+    "lodash.isplainobject": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+      "integrity": "sha1-fFJqUtibRcRcxpC4gWO+BJf1UMs=",
       "dev": true
     },
     "lodash.memoize": {
@@ -13227,9 +16041,9 @@
       }
     },
     "minizlib": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-2.1.0.tgz",
-      "integrity": "sha512-EzTZN/fjSvifSX0SlqUERCN39o6T40AMarPbv0MrarSFtIITCBh7bi+dU8nxGFHuqs9jdIAeoYoKuQAAASsPPA==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-2.1.2.tgz",
+      "integrity": "sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==",
       "dev": true,
       "requires": {
         "minipass": "^3.0.0",
@@ -14196,16 +17010,6 @@
       "dev": true,
       "requires": {
         "is-wsl": "^1.1.0"
-      }
-    },
-    "optimist": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
-      "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
-      "dev": true,
-      "requires": {
-        "minimist": "~0.0.1",
-        "wordwrap": "~0.0.2"
       }
     },
     "optionator": {
@@ -15516,13 +18320,13 @@
       "dev": true
     },
     "prompts": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/prompts/-/prompts-2.3.0.tgz",
-      "integrity": "sha512-NfbbPPg/74fT7wk2XYQ7hAIp9zJyZp5Fu19iRbORqqy1BhtrkZ0fPafBU+7bmn8ie69DpT0R6QpJIN2oisYjJg==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/prompts/-/prompts-2.3.2.tgz",
+      "integrity": "sha512-Q06uKs2CkNYVID0VqwfAl9mipo99zkBv/n2JtWY89Yxa3ZabWSrs0e2KTudKVa3peLUvYXMefDqIleLPVUBZMA==",
       "dev": true,
       "requires": {
         "kleur": "^3.0.3",
-        "sisteransi": "^1.0.3"
+        "sisteransi": "^1.0.4"
       }
     },
     "prop-types": {
@@ -15915,9 +18719,9 @@
       }
     },
     "react-dropzone": {
-      "version": "11.0.2",
-      "resolved": "https://registry.npmjs.org/react-dropzone/-/react-dropzone-11.0.2.tgz",
-      "integrity": "sha512-/Wde9Il1aJ1FtWllg3N2taIeJh4aftx6UGUG8R1TmLnZit2RnDcEjcKwEEbKwgLXTTh8QQpiZWQJq45jTy1jCA==",
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/react-dropzone/-/react-dropzone-11.1.0.tgz",
+      "integrity": "sha512-gJT6iJadyTbevrigm6KZFaei/yNWfokzs1idumO7fXtRNPiGFDUpsQ+trHWwUO3yWOtJibpbo5tLZggjm+KV5w==",
       "requires": {
         "attr-accept": "^2.0.0",
         "file-selector": "^0.1.12",
@@ -16159,6 +18963,15 @@
       "requires": {
         "loose-envify": "^1.4.0",
         "symbol-observable": "^1.2.0"
+      }
+    },
+    "redux-mock-store": {
+      "version": "1.5.4",
+      "resolved": "https://registry.npmjs.org/redux-mock-store/-/redux-mock-store-1.5.4.tgz",
+      "integrity": "sha512-xmcA0O/tjCLXhh9Fuiq6pMrJCwFRaouA8436zcikdIpYWWCjU76CRk+i2bHx8EeiSiMGnB85/lZdU3wIJVXHTA==",
+      "dev": true,
+      "requires": {
+        "lodash.isplainobject": "^4.0.6"
       }
     },
     "redux-thunk": {
@@ -16465,25 +19278,39 @@
             "psl": "^1.1.24",
             "punycode": "^1.4.1"
           }
+        },
+        "uuid": {
+          "version": "3.4.0",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+          "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
+          "dev": true
         }
       }
     },
     "request-promise-core": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/request-promise-core/-/request-promise-core-1.1.3.tgz",
-      "integrity": "sha512-QIs2+ArIGQVp5ZYbWD5ZLCY29D5CfWizP8eWnm8FoGD1TX61veauETVQbrV60662V0oFBkrDOuaBI8XgtuyYAQ==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/request-promise-core/-/request-promise-core-1.1.4.tgz",
+      "integrity": "sha512-TTbAfBBRdWD7aNNOoVOBH4pN/KigV6LyapYNNlAPA8JwbovRti1E88m3sYAwsLi5ryhPKsE9APwnjFTgdUjTpw==",
       "dev": true,
       "requires": {
-        "lodash": "^4.17.15"
+        "lodash": "^4.17.19"
+      },
+      "dependencies": {
+        "lodash": {
+          "version": "4.17.20",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+          "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
+          "dev": true
+        }
       }
     },
     "request-promise-native": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/request-promise-native/-/request-promise-native-1.0.8.tgz",
-      "integrity": "sha512-dapwLGqkHtwL5AEbfenuzjTYg35Jd6KPytsC2/TLkVMz8rm+tNt72MGUWT1RP/aYawMpN6HqbNGBQaRcBtjQMQ==",
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/request-promise-native/-/request-promise-native-1.0.9.tgz",
+      "integrity": "sha512-wcW+sIUiWnKgNY0dqCpOZkUbF/I+YPi+f09JZIDa39Ec+q82CpSYniDp+ISgTTbKmnpJWASeJBPZmoxH84wt3g==",
       "dev": true,
       "requires": {
-        "request-promise-core": "1.1.3",
+        "request-promise-core": "1.1.4",
         "stealthy-require": "^1.1.1",
         "tough-cookie": "^2.3.3"
       }
@@ -17229,6 +20056,15 @@
       "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
       "dev": true
     },
+    "saxes": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-5.0.1.tgz",
+      "integrity": "sha512-5LBh1Tls8c9xgGjw3QrMwETmTMVk0oFgvrFSvWx62llR2hcEInrKNZ2GZCCuuy2lvWrdl5jhbpeqc5hRYKFOcw==",
+      "dev": true,
+      "requires": {
+        "xmlchars": "^2.2.0"
+      }
+    },
     "scheduler": {
       "version": "0.18.0",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.18.0.tgz",
@@ -17589,9 +20425,9 @@
       }
     },
     "sisteransi": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.4.tgz",
-      "integrity": "sha512-/ekMoM4NJ59ivGSfKapeG+FWtrmWvA1p6FBZwXrqojw90vJu8lBmrTxCMuBCydKtkaUe2zt4PlxeTKpjwMbyig==",
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
+      "integrity": "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==",
       "dev": true
     },
     "slash": {
@@ -17757,6 +20593,12 @@
           "requires": {
             "websocket-driver": ">=0.5.1"
           }
+        },
+        "uuid": {
+          "version": "3.4.0",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+          "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
+          "dev": true
         }
       }
     },
@@ -18476,6 +21318,12 @@
       "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=",
       "dev": true
     },
+    "strip-final-newline": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
+      "integrity": "sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==",
+      "dev": true
+    },
     "strip-indent": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-1.0.1.tgz",
@@ -18614,6 +21462,33 @@
       "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
       "requires": {
         "has-flag": "^3.0.0"
+      }
+    },
+    "supports-hyperlinks": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/supports-hyperlinks/-/supports-hyperlinks-2.1.0.tgz",
+      "integrity": "sha512-zoE5/e+dnEijk6ASB6/qrK+oYdm2do1hjoLWrqUC/8WEIW1gbxFcKuBof7sW8ArN6e+AYvsE8HBGiVRWL/F5CA==",
+      "dev": true,
+      "requires": {
+        "has-flag": "^4.0.0",
+        "supports-color": "^7.0.0"
+      },
+      "dependencies": {
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
       }
     },
     "svg-parser": {
@@ -18966,6 +21841,14 @@
         "node-fetch": "^2.2.0",
         "stream-events": "^1.0.5",
         "uuid": "^3.3.2"
+      },
+      "dependencies": {
+        "uuid": {
+          "version": "3.4.0",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+          "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
+          "dev": true
+        }
       }
     },
     "temp-dir": {
@@ -18982,6 +21865,41 @@
       "requires": {
         "temp-dir": "^1.0.0",
         "uuid": "^3.0.1"
+      },
+      "dependencies": {
+        "uuid": {
+          "version": "3.4.0",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+          "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
+          "dev": true
+        }
+      }
+    },
+    "terminal-link": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/terminal-link/-/terminal-link-2.1.1.tgz",
+      "integrity": "sha512-un0FmiRUQNr5PJqy9kP7c40F5BOfpGlYTrxonDChEZB7pzZxRNp/bt+ymiy9/npwXya9KH99nJ/GXFIiUkYGFQ==",
+      "dev": true,
+      "requires": {
+        "ansi-escapes": "^4.2.1",
+        "supports-hyperlinks": "^2.0.0"
+      },
+      "dependencies": {
+        "ansi-escapes": {
+          "version": "4.3.1",
+          "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.1.tgz",
+          "integrity": "sha512-JWF7ocqNrp8u9oqpgV+wH5ftbt+cfvv+PTjOvKLT3AdYly/LmORARfEVT1iyjwN+4MqE5UmVKoAdIBqeoCHgLA==",
+          "dev": true,
+          "requires": {
+            "type-fest": "^0.11.0"
+          }
+        },
+        "type-fest": {
+          "version": "0.11.0",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.11.0.tgz",
+          "integrity": "sha512-OdjXJxnCN1AvyLSzeKIgXTXxV+99ZuXl3Hpo9XpJAv9MBcHrrJOQ5kV7ypXOuQie+AmWG25hLbiKdwYTifzcfQ==",
+          "dev": true
+        }
       }
     },
     "terser": {
@@ -19272,7 +22190,8 @@
     "tslib": {
       "version": "1.10.0",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.10.0.tgz",
-      "integrity": "sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ=="
+      "integrity": "sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ==",
+      "dev": true
     },
     "tty-browserify": {
       "version": "0.0.0",
@@ -19310,6 +22229,12 @@
         "prelude-ls": "~1.1.2"
       }
     },
+    "type-detect": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
+      "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
+      "dev": true
+    },
     "type-fest": {
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.6.0.tgz",
@@ -19331,6 +22256,15 @@
       "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
       "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
       "dev": true
+    },
+    "typedarray-to-buffer": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/typedarray-to-buffer/-/typedarray-to-buffer-3.1.5.tgz",
+      "integrity": "sha512-zdu8XMNEDepKKR+XYOXAVPtWui0ly0NtohUscw+UmaHiAWT8hrV1rr//H6V+0DvJ3OQ19S979M0laLfX8rm82Q==",
+      "dev": true,
+      "requires": {
+        "is-typedarray": "^1.0.0"
+      }
     },
     "uglify-js": {
       "version": "3.4.10",
@@ -19673,9 +22607,9 @@
       "dev": true
     },
     "uuid": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.3.tgz",
-      "integrity": "sha512-pW0No1RGHgzlpHJO1nsVrHKpOEIxkGg1xB+v0ZmdNH5OAeAwzAVrCnI2/6Mtx+Uys6iaylxa+D3g4j63IKKjSQ==",
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.0.tgz",
+      "integrity": "sha512-fX6Z5o4m6XsXBdli9g7DtWgAx+osMsRRZFKma1mIUsLCz6vRvv+pz5VNbyu9UEDzpMWulZfvpgb/cmDXVulYFQ==",
       "dev": true
     },
     "v8-compile-cache": {
@@ -19683,6 +22617,25 @@
       "resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.1.0.tgz",
       "integrity": "sha512-usZBT3PW+LOjM25wbqIlZwPeJV+3OSz3M1k1Ws8snlW39dZyYL9lOGC5FgPVHfk0jKmjiDV8Z0mIbVQPiwFs7g==",
       "dev": true
+    },
+    "v8-to-istanbul": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/v8-to-istanbul/-/v8-to-istanbul-5.0.1.tgz",
+      "integrity": "sha512-mbDNjuDajqYe3TXFk5qxcQy8L1msXNE37WTlLoqqpBfRsimbNcrlhQlDPntmECEcUvdC+AQ8CyMMf6EUx1r74Q==",
+      "dev": true,
+      "requires": {
+        "@types/istanbul-lib-coverage": "^2.0.1",
+        "convert-source-map": "^1.6.0",
+        "source-map": "^0.7.3"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.7.3",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.3.tgz",
+          "integrity": "sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ==",
+          "dev": true
+        }
+      }
     },
     "validate-npm-package-license": {
       "version": "3.0.4",
@@ -19729,12 +22682,21 @@
       "dev": true
     },
     "w3c-hr-time": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/w3c-hr-time/-/w3c-hr-time-1.0.1.tgz",
-      "integrity": "sha1-gqwr/2PZUOqeMYmlimViX+3xkEU=",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/w3c-hr-time/-/w3c-hr-time-1.0.2.tgz",
+      "integrity": "sha512-z8P5DvDNjKDoFIHK7q8r8lackT6l+jo/Ye3HOle7l9nICP9lf1Ci25fy9vHd0JOWewkIFzXIEig3TdKT7JQ5fQ==",
       "dev": true,
       "requires": {
-        "browser-process-hrtime": "^0.1.2"
+        "browser-process-hrtime": "^1.0.0"
+      }
+    },
+    "w3c-xmlserializer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-2.0.0.tgz",
+      "integrity": "sha512-4tzD0mF8iSiMiNs30BiLO3EpfGLZUT2MSX/G+o7ZywDzliWQ3OPtTZ0PTC3B3ca1UAf4cJMHB+2Bf56EriJuRA==",
+      "dev": true,
+      "requires": {
+        "xml-name-validator": "^3.0.0"
       }
     },
     "walker": {
@@ -20255,6 +23217,14 @@
       "requires": {
         "ansi-colors": "^3.0.0",
         "uuid": "^3.3.2"
+      },
+      "dependencies": {
+        "uuid": {
+          "version": "3.4.0",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+          "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
+          "dev": true
+        }
       }
     },
     "webpack-merge": {
@@ -20377,12 +23347,6 @@
       "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==",
       "dev": true
     },
-    "wordwrap": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
-      "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc=",
-      "dev": true
-    },
     "worker-farm": {
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/worker-farm/-/worker-farm-1.7.0.tgz",
@@ -20465,6 +23429,12 @@
       "integrity": "sha512-A5CUptxDsvxKJEU3yO6DuWBSJz/qizqzJKOMIfUJHETbBw/sFaDxgd6fxm1ewUaM0jZ444Fc5vC5ROYurg/4Pw==",
       "dev": true
     },
+    "xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true
+    },
     "xtend": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
@@ -20484,9 +23454,9 @@
       "dev": true
     },
     "yargs": {
-      "version": "13.3.0",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-13.3.0.tgz",
-      "integrity": "sha512-2eehun/8ALW8TLoIl7MVaRUrg+yCnenu8B4kBlRxj3GJGDKU1Og7sMXPNm1BYyM1DOJmTZ4YeN/Nwxv+8XJsUA==",
+      "version": "13.3.2",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-13.3.2.tgz",
+      "integrity": "sha512-AX3Zw5iPruN5ie6xGRIDgqkT+ZhnRlZMLMHAs8tg7nRruy2Nb+i5o9bwghAogtM08q1dpr2LVoS8KSTMYpWXUw==",
       "dev": true,
       "requires": {
         "cliui": "^5.0.0",
@@ -20498,7 +23468,7 @@
         "string-width": "^3.0.0",
         "which-module": "^2.0.0",
         "y18n": "^4.0.0",
-        "yargs-parser": "^13.1.1"
+        "yargs-parser": "^13.1.2"
       },
       "dependencies": {
         "string-width": {
@@ -20510,6 +23480,16 @@
             "emoji-regex": "^7.0.1",
             "is-fullwidth-code-point": "^2.0.0",
             "strip-ansi": "^5.1.0"
+          }
+        },
+        "yargs-parser": {
+          "version": "13.1.2",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-13.1.2.tgz",
+          "integrity": "sha512-3lbsNRf/j+A4QuSZfDRA7HRSfWrzO0YjqTJd5kjAq37Zep1CEgaYmrH9Q3GwPiB9cHyd1Y1UwggGhJGoxipbzg==",
+          "dev": true,
+          "requires": {
+            "camelcase": "^5.0.0",
+            "decamelize": "^1.2.0"
           }
         }
       }

--- a/package.json
+++ b/package.json
@@ -15,9 +15,12 @@
     "i18n_extract": "BABEL_ENV=i18n fedx-scripts babel src --quiet > /dev/null",
     "is-es5": "es-check es5 ./dist/*.js",
     "lint": "fedx-scripts eslint --ext .js --ext .jsx .",
+    "lint:fix": "fedx-scripts eslint --ext .js --ext .jsx . --fix",
     "snapshot": "fedx-scripts jest --updateSnapshot",
     "start": "fedx-scripts webpack-dev-server --progress",
-    "test": "fedx-scripts jest --coverage --passWithNoTests"
+    "test": "fedx-scripts jest --coverage",
+    "test:watch": "fedx-scripts jest --coverage --watchAll --watch",
+    "clear-jest": "fedx-scripts jest --clearCache"
   },
   "husky": {
     "hooks": {
@@ -49,7 +52,7 @@
     "prop-types": "15.7.2",
     "react": "16.12.0",
     "react-dom": "16.12.0",
-    "react-dropzone": "^11.0.2",
+    "react-dropzone": "^11.1.0",
     "react-redux": "7.1.3",
     "react-router": "5.1.2",
     "react-router-dom": "5.1.2",
@@ -58,14 +61,19 @@
   },
   "devDependencies": {
     "@edx/frontend-build": "3.0.0",
+    "@sheerun/mutationobserver-shim": "^0.3.3",
+    "@testing-library/dom": "^7.24.2",
+    "@testing-library/react": "^11.0.4",
     "codecov": "3.7.1",
-    "copy-webpack-plugin": "^6.0.3",
+    "copy-webpack-plugin": "^6.1.0",
     "es-check": "5.1.0",
     "glob": "7.1.6",
     "husky": "3.1.0",
-    "jest": "24.9.0",
+    "jest": "26.4.2",
     "reactifex": "1.1.1",
+    "redux-mock-store": "^1.5.4",
     "rosie": "2.0.1",
+    "uuid": "^8.3.0",
     "webpack-merge": "4.2.2"
   }
 }

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -18,6 +18,7 @@ import {
   LibraryPage,
   LibraryListPage,
   StudioHeader,
+  LibraryAccessPage,
 } from './library-authoring';
 import './index.scss';
 import './assets/favicon.ico';
@@ -37,6 +38,7 @@ subscribe(APP_READY, () => {
             <Route exact path={ROUTES.List.HOME} component={LibraryListPage} />
             <Route exact path={ROUTES.Detail.HOME} component={LibraryPage} />
             <Route exact path={ROUTES.Detail.EDIT} component={LibraryEditPage} />
+            <Route exact path={ROUTES.Detail.ACCESS} component={LibraryAccessPage} />
             <Route exact path={ROUTES.Block.HOME} component={LibraryBlockPage} />
             <Route exact path={ROUTES.Block.EDIT} component={LibraryBlockPage} />
             <Route exact path={ROUTES.Block.ASSETS} component={LibraryBlockPage} />

--- a/src/library-authoring/common/data/constants.js
+++ b/src/library-authoring/common/data/constants.js
@@ -1,4 +1,6 @@
 export const LIBRARY_TYPES = {
+  VIDEO: 'video', // blockstore/v2
+  PROBLEM: 'problem', // blockstore/v2
   COMPLEX: 'complex', // blockstore/v2
   LEGACY: 'legacy', // modulestore/v1
 };

--- a/src/library-authoring/common/data/constants.js
+++ b/src/library-authoring/common/data/constants.js
@@ -16,6 +16,12 @@ export const SUBMISSION_STATUS = {
   FAILED: 'failed',
 };
 
+export const LIBRARY_ACCESS = {
+  ADMIN: 'admin',
+  AUTHOR: 'author',
+  READ: 'read',
+};
+
 export const ROUTES = {
   List: {
     HOME: '/',
@@ -25,6 +31,8 @@ export const ROUTES = {
     HOME_SLUG: (libraryId) => `/library/${libraryId}`,
     EDIT: '/library/:libraryId/edit',
     EDIT_SLUG: (libraryId) => `/library/${libraryId}/edit`,
+    ACCESS: '/library/:libraryId/access',
+    ACCESS_SLUG: (libraryId) => `/library/${libraryId}/access`,
   },
   Block: {
     HOME: '/library/:libraryId/blocks/:blockId',

--- a/src/library-authoring/common/index.scss
+++ b/src/library-authoring/common/index.scss
@@ -29,3 +29,11 @@
     }
   }
 }
+
+.well {
+  border: 1px solid $gray-l3;
+  border-radius: ($baseline/4);
+  box-shadow: 0 1px 3px $shadow inset;
+  background-color: $gray-l5;
+  padding: ($baseline/2);
+}

--- a/src/library-authoring/common/messages.js
+++ b/src/library-authoring/common/messages.js
@@ -11,6 +11,26 @@ const messages = defineMessages({
     defaultMessage: 'Libraries',
     description: 'Text on the libraries tab.',
   },
+  'library.common.forms.button.cancel': {
+    id: 'library.common.forms.cancel',
+    defaultMessage: 'Cancel',
+    description: 'Default label for "Cancel" buttons.',
+  },
+  'library.common.forms.button.submit': {
+    id: 'library.common.forms.button.submit',
+    defaultMessage: 'Submit',
+    description: 'Default label for "Submit" buttons.',
+  },
+  'library.common.forms.button.submitting': {
+    id: 'library.common.forms.button.submitting',
+    defaultMessage: 'Submitting...',
+    description: 'Default label for "Submit" buttons when currently submitting.',
+  },
+  'library.common.forms.button.yes': {
+    id: 'library.common.forms.button.yes',
+    defaultMessage: 'Yes.',
+    description: 'Default label for "Yes" on a confirmation prompt.',
+  },
 });
 
 export default messages;

--- a/src/library-authoring/common/specs/constants.js
+++ b/src/library-authoring/common/specs/constants.js
@@ -1,0 +1,19 @@
+export const VIDEO_TYPE = {
+  block_type: 'video',
+  display_name: 'Video',
+};
+
+export const PROBLEM_TYPE = {
+  block_type: 'problem',
+  display_name: 'Problem',
+};
+
+export const HTML_TYPE = {
+  block_type: 'html',
+  display_name: 'HTML',
+};
+
+export const POLL_TYPE = {
+  block_type: 'poll',
+  display_name: 'Poll',
+};

--- a/src/library-authoring/common/specs/factories.js
+++ b/src/library-authoring/common/specs/factories.js
@@ -1,0 +1,53 @@
+// Factories should generate new objects with unique data so that they're not always the same.
+import { v4 as uuidv4 } from 'uuid';
+import { LIBRARY_ACCESS } from '../data';
+import {
+  HTML_TYPE, POLL_TYPE, PROBLEM_TYPE, VIDEO_TYPE,
+} from './constants';
+import { makeManufacturer } from './helpers';
+
+const currentIds = {
+  user: 0,
+  library: 0,
+};
+
+
+export function userFactory(overrides) {
+  currentIds.user += 1;
+  const id = currentIds.user;
+  return {
+    username: `TestUser${id}`,
+    email: `example${id}@example.com`,
+    access_level: LIBRARY_ACCESS.READ,
+    ...overrides,
+  };
+}
+
+
+export function libraryFactory(overrides) {
+  currentIds.library += 1;
+  const id = currentIds.library;
+  const base = {
+    org: `TestOrg${id}`,
+    slug: `TestSlug${id}`,
+    bundle_uuid: uuidv4(),
+    title: `Test library ${id}`,
+    description: `This is a test library, number ${id} in the sequence.`,
+    version: 0,
+    has_unpublished_changes: false,
+    has_unpublished_deletes: false,
+    blocks: [],
+    blockTypes: [VIDEO_TYPE, POLL_TYPE, HTML_TYPE, PROBLEM_TYPE],
+    ...overrides,
+  };
+  return {
+    ...base,
+    id: `lib:${base.org}:${base.slug}`,
+    // Use overrides one more time in case id was overridden.
+    ...overrides,
+  };
+}
+
+
+export const userFactoryLine = makeManufacturer(userFactory);
+export const libraryFactoryLine = makeManufacturer(libraryFactory);

--- a/src/library-authoring/common/specs/helpers.jsx
+++ b/src/library-authoring/common/specs/helpers.jsx
@@ -1,0 +1,114 @@
+// eslint-disable-next-line import/no-extraneous-dependencies
+import jest from 'jest-mock';
+import { render } from '@testing-library/react';
+import AppContext from '@edx/frontend-platform/react/AppContext';
+import { IntlProvider } from '@edx/frontend-platform/i18n';
+import * as React from 'react';
+
+/**
+ * mocksFromNames
+ * Given an iterable of strings, creates an object with those strings as properties and the values as mocks.
+ * @param names
+ * @returns {{}}
+ */
+export function mocksFromNames(names) {
+  const result = {};
+  // eslint-disable-next-line no-restricted-syntax
+  for (const name of names) {
+    result[name] = jest.fn();
+  }
+  return result;
+}
+
+/**
+ * toInfiniteGenerator
+ *
+ * Turns any iterable into a generator that never exhausts, but instead returns 'undefined' after the initial iterator
+ * is exhausted.
+ *
+ * @param iterable Iterable<any>
+ * @returns {Generator<undefined|any, void, *>}
+ */
+function* toInfiniteGenerator(iterable) {
+  // eslint-disable-next-line no-restricted-syntax
+  for (const item of iterable) {
+    yield item;
+  }
+  while (true) {
+    yield undefined;
+  }
+}
+
+/**
+ * manufacturer
+ * A function for cranking out instances from a factory. For example, if you have a factory named 'userFactory',
+ * you can call this on that factory and get a generator function that can produce users on demand.
+ *
+ * The resulting function can be handed a list of overrides that will be used to override the defaults of the users.
+ *
+ * const userFactoryLine = manufacturer(userFactory)
+ * const [user1, user2, user3, user4] = userFactoryLine([{username: 'Dude'}, {}, {email: 'stuff@things.com}])
+ *
+ * ...will create user1 with the username 'Dude', user2 with the defaults, user3 with the email 'stuff@things.com',
+ * and user4 with the defaults.
+ *
+ * If you don't need to unpack the manufactured objects into variable names, but just need a quick list of objects, you
+ * can use the makeN function below.
+ *
+ * const line = userFactoryLine([{username: 'Dude'}, {}, {email: 'stuff@things.com}])
+ * const users = makeN(line, 6)
+ *
+ * @param wrapped: A factory function.
+ * @returns {function(*=): Generator<*, void, *>}
+ */
+export function makeManufacturer(wrapped) {
+  // I've stretched this metaphor so far I think I can see through it.
+  function* conveyorBelt(overridesList) {
+    const infiniteGenerator = toInfiniteGenerator(overridesList || []);
+    while (true) {
+      yield wrapped(infiniteGenerator.next().value);
+    }
+  }
+
+  return conveyorBelt;
+}
+
+/**
+ * makeN
+ *
+ * Takes a generator and runs over it N times, returning the results in an array.
+ *
+ * @param generator Generator<any>: A generator function
+ * @param count: A number indicating how many iterations of the generator you want to pull into an array.
+ * @returns {any[]}
+ */
+export function makeN(generator, count) {
+  const result = [];
+  for (let i = 0; i < count; i += 1) {
+    result.push(generator.next().value);
+  }
+  return result;
+}
+
+export const ctxRender = (ui, context) => render(
+  <AppContext.Provider value={context}>
+    <IntlProvider locale="en">
+      {ui}
+    </IntlProvider>
+  </AppContext.Provider>,
+);
+
+/**
+ * immediate
+ *
+ * Creates a promise which resolves immediately with a given value. Good for use when an API requires a promise, but
+ * you already have the required data.
+ *
+ * @param val
+ * @returns {Promise<any>}
+ */
+export function immediate(val) {
+  return new Promise((resolve) => {
+    resolve(val);
+  });
+}

--- a/src/library-authoring/create-library/LibraryCreateForm.jsx
+++ b/src/library-authoring/create-library/LibraryCreateForm.jsx
@@ -21,6 +21,7 @@ import {
   selectLibraryCreate,
 } from './data';
 
+import commonMessages from '../common/messages';
 import messages from './messages';
 
 class LibraryCreateForm extends React.Component {
@@ -237,9 +238,9 @@ class LibraryCreateForm extends React.Component {
           <StatefulButton
             state={this.getSubmitButtonState()}
             labels={{
-              disabled: intl.formatMessage(messages['library.form.button.submit']),
-              enabled: intl.formatMessage(messages['library.form.button.submit']),
-              pending: intl.formatMessage(messages['library.form.button.submitting']),
+              disabled: intl.formatMessage(commonMessages['library.common.forms.button.submit']),
+              enabled: intl.formatMessage(commonMessages['library.common.forms.button.submit']),
+              pending: intl.formatMessage(commonMessages['library.common.forms.button.submitting']),
             }}
             icons={{
               pending: <Icon className="fa fa-spinner fa-spin" />,
@@ -252,7 +253,7 @@ class LibraryCreateForm extends React.Component {
             className="action btn-light"
             onClick={this.onCancel}
           >
-            {intl.formatMessage(messages['library.form.button.cancel'])}
+            {intl.formatMessage(commonMessages['library.common.forms.button.cancel'])}
           </Button>
         </div>
       </form>

--- a/src/library-authoring/create-library/LibraryCreateForm.jsx
+++ b/src/library-authoring/create-library/LibraryCreateForm.jsx
@@ -51,10 +51,10 @@ class LibraryCreateForm extends React.Component {
       && createdLibrary !== prevProps.createdLibrary
       && createdLibrary !== null
     ) {
-      if (createdLibrary.type === LIBRARY_TYPES.COMPLEX) {
-        this.props.history.push(createdLibrary.url);
-      } else if (createdLibrary.type === LIBRARY_TYPES.LEGACY) {
+      if (createdLibrary.type === LIBRARY_TYPES.LEGACY) {
         window.location.href = createdLibrary.url;
+      } else if (Object.values(LIBRARY_TYPES).includes(createdLibrary.type)) {
+        this.props.history.push(createdLibrary.url);
       }
     }
   }

--- a/src/library-authoring/create-library/data/api.js
+++ b/src/library-authoring/create-library/data/api.js
@@ -15,23 +15,7 @@ export async function createLibrary({ type, ...data }) {
 
   let response;
   let library;
-  if (type === LIBRARY_TYPES.COMPLEX) {
-    response = await client.post(`${STUDIO_BASE_URL}/api/libraries/v2/`, {
-      ...data,
-      description: data.title,
-      collection_uuid: BLOCKSTORE_COLLECTION_UUID,
-    }).catch((error) => {
-      /* Normalize error data. */
-      const apiError = Object.create(error);
-      apiError.message = null;
-      apiError.fields = JSON.parse(error.customAttributes.httpErrorResponseData);
-      throw apiError;
-    });
-    library = {
-      ...response.data,
-      type,
-    };
-  } else if (type === LIBRARY_TYPES.LEGACY) {
+  if (type === LIBRARY_TYPES.LEGACY) {
     response = await client.post(`${STUDIO_BASE_URL}/library/`, {
       org: data.org,
       number: data.slug,
@@ -51,8 +35,25 @@ export async function createLibrary({ type, ...data }) {
       title: data.title,
       description: null,
       version: null,
+      type: LIBRARY_TYPES.LEGACY,
       has_unpublished_changes: false,
       has_unpublished_deletes: false,
+    };
+  } else if (Object.values(LIBRARY_TYPES).includes(type)) {
+    response = await client.post(`${STUDIO_BASE_URL}/api/libraries/v2/`, {
+      ...data,
+      type,
+      description: data.title,
+      collection_uuid: BLOCKSTORE_COLLECTION_UUID,
+    }).catch((error) => {
+      /* Normalize error data. */
+      const apiError = Object.create(error);
+      apiError.message = null;
+      apiError.fields = JSON.parse(error.customAttributes.httpErrorResponseData);
+      throw apiError;
+    });
+    library = {
+      ...response.data,
       type,
     };
   } else {

--- a/src/library-authoring/create-library/messages.js
+++ b/src/library-authoring/create-library/messages.js
@@ -68,16 +68,6 @@ const messages = defineMessages({
     defaultMessage: 'The type of library that will be created.',
     description: 'Help text for the type field.',
   },
-  'library.form.button.submit': {
-    id: 'library.form.button.submit',
-    defaultMessage: 'Create',
-    description: 'Text for the submit button.',
-  },
-  'library.form.button.submitting': {
-    id: 'library.form.button.submitting',
-    defaultMessage: 'Creating',
-    description: 'Text for the submit button when submitting.',
-  },
   'library.form.button.cancel': {
     id: 'library.form.button.cancel',
     defaultMessage: 'Cancel',

--- a/src/library-authoring/create-library/messages.js
+++ b/src/library-authoring/create-library/messages.js
@@ -73,9 +73,19 @@ const messages = defineMessages({
     defaultMessage: 'Cancel',
     description: 'Text for the cancel button.',
   },
+  'library.form.type.label.video': {
+    id: 'library.form.type.label.video',
+    defaultMessage: 'Video (beta)',
+    description: 'Label for the video library type.',
+  },
+  'library.form.type.label.problem': {
+    id: 'library.form.type.label.problem',
+    defaultMessage: 'Problem (beta)',
+    description: 'Label for the problem library type.',
+  },
   'library.form.type.label.complex': {
     id: 'library.form.type.label.complex',
-    defaultMessage: 'Complex',
+    defaultMessage: 'Complex (beta)',
     description: 'Label for the complex library type.',
   },
   'library.form.type.label.legacy': {

--- a/src/library-authoring/edit-library/LibraryEditPage.jsx
+++ b/src/library-authoring/edit-library/LibraryEditPage.jsx
@@ -19,7 +19,7 @@ import {
   LOADING_STATUS,
   SUBMISSION_STATUS,
   libraryShape,
-  truncateErrorMessage,
+  truncateErrorMessage, LIBRARY_TYPES,
 } from '../common';
 import {
   fetchLibraryDetail,
@@ -37,9 +37,10 @@ class LibraryEditPage extends React.Component {
     super(props);
     this.state = {
       data: {
-        id: null,
+        libraryId: null,
         title: '',
         description: '',
+        type: null,
         allow_public_learning: false,
         allow_public_read: false,
       },
@@ -75,6 +76,7 @@ class LibraryEditPage extends React.Component {
         libraryId: library.id,
         title: library.title,
         description: library.description,
+        type: library.type,
         allow_public_learning: library.allow_public_learning,
         allow_public_read: library.allow_public_read,
       },
@@ -143,6 +145,10 @@ class LibraryEditPage extends React.Component {
     this.props.updateLibrary({ data: this.state.data });
   }
 
+  componentWillUnmount = () => {
+    this.props.clearError();
+  }
+
   handleCancel = () => {
     this.props.history.push(this.props.library.url);
   }
@@ -158,6 +164,11 @@ class LibraryEditPage extends React.Component {
   renderContent() {
     const { errorMessage, intl, library } = this.props;
     const { data } = this.state;
+
+    const validTypes = Object.values(LIBRARY_TYPES).filter((type) => type !== LIBRARY_TYPES.LEGACY);
+    const typeOptions = validTypes.map((value) => (
+      { value, label: intl.formatMessage(messages[`library.edit.type.label.${value}`]) }
+    ));
 
     return (
       <div className="library-edit-wrapper">
@@ -226,6 +237,28 @@ class LibraryEditPage extends React.Component {
                           onChange={this.handleValueChange}
                         />
                       </ValidationFormGroup>
+                    </li>
+                    <li className="field">
+                      {data.libraryId && (
+                        <ValidationFormGroup
+                          for="type"
+                          helpText={intl.formatMessage(messages['library.edit.type.help'])}
+                          invalid={this.hasFieldError('type')}
+                          invalidMessage={this.getFieldError('type')}
+                          className="mb-0 mr-2"
+                        >
+                          <label className="h6 d-block" htmlFor="type">
+                            {intl.formatMessage(messages['library.edit.type.label'])}
+                          </label>
+                          <Input
+                            name="type"
+                            type="select"
+                            options={typeOptions}
+                            defaultValue={data.type}
+                            onChange={this.handleValueChange}
+                          />
+                        </ValidationFormGroup>
+                      ) }
                     </li>
                     <li className="field">
                       <Form.Group>

--- a/src/library-authoring/edit-library/data/thunks.js
+++ b/src/library-authoring/edit-library/data/thunks.js
@@ -14,5 +14,5 @@ export const updateLibrary = ({ data }) => async (dispatch) => {
 };
 
 export const clearError = () => async (dispatch) => {
-  dispatch(actions.libraryEditClearError());
+  dispatch(actions.libraryClearError());
 };

--- a/src/library-authoring/edit-library/messages.js
+++ b/src/library-authoring/edit-library/messages.js
@@ -41,6 +41,31 @@ const messages = defineMessages({
     defaultMessage: 'The description for your library.',
     description: 'Help text for the description field.',
   },
+  'library.edit.type.label': {
+    id: 'library.edit.type.label',
+    defaultMessage: 'Library Type *',
+    description: 'Label for the type field.',
+  },
+  'library.edit.type.help': {
+    id: 'library.edit.type.help',
+    defaultMessage: 'The type of library.',
+    description: 'Help text for the type field.',
+  },
+  'library.edit.type.label.video': {
+    id: 'library.edit.type.label.video',
+    defaultMessage: 'Video (beta)',
+    description: 'Label for the video library type.',
+  },
+  'library.edit.type.label.problem': {
+    id: 'library.edit.type.label.problem',
+    defaultMessage: 'Problem (beta)',
+    description: 'Label for the problem library type.',
+  },
+  'library.edit.type.label.complex': {
+    id: 'library.edit.type.label.complex',
+    defaultMessage: 'Complex (beta)',
+    description: 'Label for the complex library type.',
+  },
   'library.edit.public_learning.label': {
     id: 'library.edit.public_learning.label',
     defaultMessage: 'Allow public learning',

--- a/src/library-authoring/index.js
+++ b/src/library-authoring/index.js
@@ -5,3 +5,4 @@ export * from './edit-library';
 export * from './library-detail';
 export * from './list-libraries';
 export * from './studio-header';
+export * from './library-access';

--- a/src/library-authoring/index.scss
+++ b/src/library-authoring/index.scss
@@ -3,3 +3,4 @@
 @import './studio-header/index.scss';
 @import './list-libraries/index.scss';
 @import './library-detail/index.scss';
+@import './library-access/index.scss';

--- a/src/library-authoring/library-access/LibraryAccessForm.jsx
+++ b/src/library-authoring/library-access/LibraryAccessForm.jsx
@@ -185,6 +185,8 @@ LibraryAccessFormContainer.propTypes = {
   }),
 };
 
+export const RawLibraryAccessFormContainer = LibraryAccessFormContainer;
+
 export default connect(
   selectLibraryAccess,
   {

--- a/src/library-authoring/library-access/LibraryAccessForm.jsx
+++ b/src/library-authoring/library-access/LibraryAccessForm.jsx
@@ -1,0 +1,194 @@
+/*
+Form for adding a new Library user.
+ */
+import {
+  Button, Card, Icon, Input, Row, StatefulButton, ValidationFormGroup,
+} from '@edx/paragon';
+import React, { useCallback, useState } from 'react';
+import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
+import { injectIntl, intlShape } from '@edx/frontend-platform/i18n';
+import { LIBRARY_ACCESS, libraryShape, SUBMISSION_STATUS } from '../common/data';
+import messages from './messages';
+import commonMessages from '../common/messages';
+import {
+  addUser, clearAccessErrors, libraryAccessInitialState, selectLibraryAccess,
+} from './data';
+
+/**
+ * LibraryAccessForm:
+ * Template component for the form used to add a new user to a library.
+ */
+const LibraryAccessForm = (
+  {
+    intl, onSubmit, setShowAdd, hasFieldError, getFieldError, data,
+    onValueChange, submitButtonState,
+  },
+) => (
+  <>
+    <Row className="mb-2">
+      <form className="col-12" onSubmit={onSubmit}>
+        <Card>
+          <Card.Body>
+            <div className="form-create">
+              <Card.Title>{intl.formatMessage(messages['library.access.form.title'])}</Card.Title>
+              <fieldset>
+                <ol className="list-input">
+                  <li className="field">
+                    <ValidationFormGroup
+                      for="title"
+                      helpText={intl.formatMessage(messages['library.access.form.email.help'])}
+                      invalid={hasFieldError('email')}
+                      invalidMessage={getFieldError('email')}
+                      className="mb-0 mr-2"
+                    >
+                      <label className="h6 d-block" htmlFor="email">
+                        {intl.formatMessage(messages['library.access.form.email.label'])}
+                      </label>
+                      <Input
+                        name="email"
+                        id="email"
+                        type="text"
+                        placeholder={intl.formatMessage(messages['library.access.form.email.placeholder'])}
+                        value={data.email}
+                        onChange={onValueChange}
+                      />
+                    </ValidationFormGroup>
+                  </li>
+                </ol>
+              </fieldset>
+            </div>
+          </Card.Body>
+        </Card>
+        <Card className="mb-5">
+          <Card.Body>
+            <StatefulButton
+              variant="primary"
+              type="submit"
+              size="lg"
+              state={submitButtonState}
+              labels={{
+                disabled: intl.formatMessage(commonMessages['library.common.forms.button.submit']),
+                enabled: intl.formatMessage(commonMessages['library.common.forms.button.submit']),
+                pending: intl.formatMessage(commonMessages['library.common.forms.button.submitting']),
+              }}
+              icons={{
+                pending: <Icon className="fa fa-spinner fa-spin" />,
+              }}
+              disabledStates={['disabled', 'pending']}
+              className="font-weight-bold text-uppercase"
+            />
+            <Button size="lg" variant="secondary" className="mx-3 font-weight-bold text-uppercase" onClick={() => setShowAdd(false)}>
+              {intl.formatMessage(commonMessages['library.common.forms.button.cancel'])}
+            </Button>
+          </Card.Body>
+        </Card>
+      </form>
+    </Row>
+  </>
+);
+
+LibraryAccessForm.propTypes = {
+  intl: intlShape.isRequired,
+  data: PropTypes.shape({
+    email: PropTypes.string, access_level: PropTypes.string,
+  }).isRequired,
+  onValueChange: PropTypes.func.isRequired,
+  onSubmit: PropTypes.func.isRequired,
+  setShowAdd: PropTypes.func.isRequired,
+  hasFieldError: PropTypes.func.isRequired,
+  getFieldError: PropTypes.func.isRequired,
+  submitButtonState: PropTypes.string.isRequired,
+};
+
+const initialFormState = () => ({
+  email: '',
+  access_level: LIBRARY_ACCESS.READ,
+});
+
+/**
+ * LibraryAccessFormContainer:
+ * Container for the LibraryAccessForm. This wraps LibraryAccessForm
+ * and handles state for it, and manages the API call for adding a
+ * new user to a library team.
+ */
+const LibraryAccessFormContainer = (
+  props,
+) => {
+  const [data, setData] = useState({
+    email: '',
+    access_level: LIBRARY_ACCESS.READ,
+  });
+
+  const onSubmit = useCallback((event) => {
+    event.preventDefault();
+    props.addUser({ libraryId: props.library.id, data }).then(() => {
+      setData(initialFormState());
+    }).catch(() => undefined);
+  }, [props, data]);
+
+  const onValueChange = useCallback((event) => {
+    const { name, value } = event.target;
+    setData(current => (
+      {
+        ...current,
+        [name]: value,
+      }
+    ));
+  }, [setData]);
+
+  const hasFieldError = (fieldName) => !!(props.errorFields && (fieldName in props.errorFields));
+
+  const getFieldError = (fieldName) => {
+    if (hasFieldError(fieldName)) {
+      return props.errorFields[fieldName];
+    }
+    return null;
+  };
+
+  let submitButtonState;
+  if (props.submissionStatus === SUBMISSION_STATUS.SUBMITTING) {
+    submitButtonState = 'pending';
+  } else if (data.email.match(/.+@.+[.].+/)) {
+    submitButtonState = 'enabled';
+  } else {
+    submitButtonState = 'disabled';
+  }
+
+  return (
+    <LibraryAccessForm
+      intl={props.intl}
+      library={props.library}
+      data={data}
+      submitButtonState={submitButtonState}
+      clearAccessErrors={props.clearAccessErrors}
+      hasFieldError={hasFieldError}
+      getFieldError={getFieldError}
+      onValueChange={onValueChange}
+      onSubmit={onSubmit}
+      setShowAdd={props.setShowAdd}
+    />
+  );
+};
+
+LibraryAccessFormContainer.defaultProps = libraryAccessInitialState;
+
+LibraryAccessFormContainer.propTypes = {
+  intl: intlShape.isRequired,
+  library: libraryShape.isRequired,
+  clearAccessErrors: PropTypes.func.isRequired,
+  addUser: PropTypes.func.isRequired,
+  setShowAdd: PropTypes.func.isRequired,
+  submissionStatus: PropTypes.oneOf(Object.values(SUBMISSION_STATUS)).isRequired,
+  errorFields: PropTypes.shape({
+    email: PropTypes.string,
+  }),
+};
+
+export default connect(
+  selectLibraryAccess,
+  {
+    clearAccessErrors,
+    addUser,
+  },
+)(injectIntl(LibraryAccessFormContainer));

--- a/src/library-authoring/library-access/LibraryAccessPage.jsx
+++ b/src/library-authoring/library-access/LibraryAccessPage.jsx
@@ -1,0 +1,269 @@
+/*
+Library Access Page. This component handles team permissions access.
+ */
+import React, { useContext, useEffect, useState } from 'react';
+import PropTypes from 'prop-types';
+import { injectIntl, intlShape } from '@edx/frontend-platform/i18n';
+import { connect } from 'react-redux';
+import { withRouter } from 'react-router';
+import {
+  Alert, Button, Col, Row,
+} from '@edx/paragon';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { faPlus } from '@fortawesome/free-solid-svg-icons';
+import { AppContext } from '@edx/frontend-platform/react';
+import messages from './messages';
+import { LoadingPage } from '../../generic';
+import { fetchLibraryDetail } from '../library-detail/data';
+import LibraryAccessFormContainer from './LibraryAccessForm';
+import {
+  LIBRARY_ACCESS, libraryShape, LOADING_STATUS, ROUTES, truncateErrorMessage,
+} from '../common/data';
+import {
+  addUser,
+  clearAccess,
+  clearAccessErrors,
+  fetchUserList,
+  libraryAccessInitialState,
+  libraryUserShape,
+  selectLibraryAccess,
+} from './data';
+// eslint-disable-next-line import/no-named-as-default
+import UserAccessContainer from './UserAccessContainer';
+
+
+/**
+ * LibraryAccessPage:
+ * Template component for the access management page for libraries.
+ */
+const LibraryAccessPage = ({
+  intl, library, users, setShowAdd, errorMessage, showAdd, handleDismissAlert, multipleAdmins, isAdmin,
+}) => (
+  <div className="library-access-wrapper">
+    <div className="wrapper-mast wrapper">
+      <header className="mast has-actions has-navigation has-subtitle">
+        <div className="page-header">
+          <small className="subtitle">{intl.formatMessage(messages['library.access.page.parent_heading'])}</small>
+          <h1 className="page-header-title">{intl.formatMessage(messages['library.access.page.heading'])}</h1>
+        </div>
+        <nav className="nav-actions">
+          <ul>
+            {isAdmin && (
+              <li className="nav-item">
+                <Button
+                  variant="success"
+                  onClick={() => setShowAdd(true)}
+                >
+                  <FontAwesomeIcon icon={faPlus} className="pr-3 icon-inline" />
+                  {intl.formatMessage(messages['library.access.new.user'])}
+                </Button>
+              </li>
+            )}
+          </ul>
+        </nav>
+      </header>
+    </div>
+    <div className="wrapper-content wrapper">
+      <section className="content">
+        <article className="content-primary" role="main">
+          {errorMessage
+          && (
+            <Alert
+              variant="danger"
+              onClose={() => handleDismissAlert()}
+              dismissible
+            >
+              {truncateErrorMessage(errorMessage)}
+            </Alert>
+          )}
+          {showAdd
+          && (
+            <LibraryAccessFormContainer
+              setShowAdd={(value) => setShowAdd(value)}
+              library={library}
+            />
+          )}
+          <Row>
+            { ((users && users.map((user) => (
+              (
+                <UserAccessContainer
+                  intl={intl}
+                  user={user}
+                  key={user.username}
+                  multipleAdmins={multipleAdmins}
+                  library={library}
+                  isAdmin={isAdmin}
+                />
+              ))))
+              || (
+                <Col cols={12} className="text-center">
+                  <LoadingPage loadingMessage={intl.formatMessage(messages['library.access.loading.message'])} />
+                </Col>
+              )
+            )}
+          </Row>
+          {isAdmin && (
+            <div className="well mt-3">
+              <Row className="h-100">
+                <Col xs={12} md={8} className="my-auto">
+                  <h2 className="h2 font-weight-bold">{intl.formatMessage(messages['library.access.well.title'])}</h2>
+                  <p>{intl.formatMessage(messages['library.access.well.text'])}</p>
+                </Col>
+                <Col xs={12} md={4} lg={3} className="my-auto offset-lg-1 text-center text-md-right">
+                  <Button variant="success" size="lg" onClick={() => setShowAdd(true)}>
+                    <FontAwesomeIcon icon={faPlus} className="pr-1 icon-inline" />
+                    <strong>{intl.formatMessage(messages['library.access.well.button'])}</strong>
+                  </Button>
+                </Col>
+              </Row>
+            </div>
+          )}
+        </article>
+        <aside className="content-supplementary">
+          <div className="bit">
+            <h3 className="title title-3">{intl.formatMessage(messages['library.access.aside.title'])}</h3>
+            <p>{intl.formatMessage(messages['library.access.aside.text.first'])}</p>
+            <p>{intl.formatMessage(messages['library.access.aside.text.second'])}</p>
+            <p>{intl.formatMessage(messages['library.access.aside.text.third'])}</p>
+            <p>{intl.formatMessage(messages['library.access.aside.text.fourth'])}</p>
+
+          </div>
+        </aside>
+      </section>
+    </div>
+  </div>
+);
+
+LibraryAccessPage.defaultProps = { ...libraryAccessInitialState };
+
+LibraryAccessPage.propTypes = {
+  intl: intlShape.isRequired,
+  library: libraryShape,
+  users: PropTypes.arrayOf(libraryUserShape),
+  setShowAdd: PropTypes.func.isRequired,
+  errorMessage: PropTypes.string,
+  showAdd: PropTypes.bool.isRequired,
+  handleDismissAlert: PropTypes.func.isRequired,
+  multipleAdmins: PropTypes.bool.isRequired,
+  isAdmin: PropTypes.bool.isRequired,
+};
+
+/**
+ * LibraryAccessPageContainer:
+ * Widget for editing the list of users with access to this content library.
+ * This wraps LibraryAccessPage and handles API calls to fetch/write data, as well as displaying
+ * a loading message during initial loading. This separation allows LibraryAccessPage to be tested
+ * in unit tests without needing to mock the API.
+ */
+const LibraryAccessPageContainer = ({
+  intl, users, errorMessage, ...props
+}) => {
+  const [showAdd, setShowAdd] = useState(false);
+  const multipleAdmins = !!(users && users.filter((user) => user.access_level === 'admin').length >= 2);
+  const { authenticatedUser } = useContext(AppContext);
+  let libraryAdmin = (users && users.filter((user) => (
+    (user.username === authenticatedUser.username)
+    && (user.access_level === LIBRARY_ACCESS.ADMIN)
+  )));
+  // This array is special somehow and despite being empty will eval as true.
+  libraryAdmin = !!(libraryAdmin || []).length;
+  const isAdmin = !!(authenticatedUser.administrator || libraryAdmin);
+
+  // Explicit empty dependencies means on mount.
+  useEffect(() => {
+    const { libraryId } = props.match.params;
+    if (props.library === null) {
+      props.fetchLibraryDetail({ libraryId });
+    }
+    if (users === null) {
+      props.fetchUserList({ libraryId });
+    }
+  }, []);
+  // Returning a function with an empty dependencies list indicates this is to be done on unmount,
+  // rather than on data change.
+  useEffect(() => () => {
+    props.clearAccess();
+  }, []);
+
+  useEffect(() => {
+    // To be done on each data reload. If the user's list doesn't contain the user, or if the user now no longer has
+    // staff privs, we need to send the user back to the libraries index.
+    if (users === null) {
+      // Still loading. Ignore.
+      return;
+    }
+    const admin = users.filter((user) => user.username === authenticatedUser.username)[0];
+    if ((admin === undefined) || admin.access_level === LIBRARY_ACCESS.READ) {
+      props.history.replace(ROUTES.List.HOME);
+    }
+  });
+
+  const handleDismissAlert = () => {
+    props.clearAccessErrors();
+  };
+
+  const renderLoading = () => (
+    <LoadingPage loadingMessage={intl.formatMessage(messages['library.access.loading.message'])} />
+  );
+
+  const renderContent = () => (
+    <LibraryAccessPage
+      setShowAdd={setShowAdd}
+      errorMessage={errorMessage}
+      handleDismissAlert={handleDismissAlert}
+      intl={intl}
+      showAdd={showAdd}
+      users={users}
+      multipleAdmins={multipleAdmins}
+      isAdmin={isAdmin}
+    />
+  );
+
+  let content;
+  if (props.loadingStatus === LOADING_STATUS.LOADING) {
+    content = renderLoading();
+  } else {
+    content = renderContent();
+  }
+
+  return (
+    <div className="container-fluid">
+      {content}
+    </div>
+  );
+};
+
+
+LibraryAccessPageContainer.propTypes = {
+  // errorMessage: PropTypes.string,
+  intl: intlShape.isRequired,
+  library: libraryShape,
+  errorMessage: PropTypes.string,
+  fetchLibraryDetail: PropTypes.func.isRequired,
+  fetchUserList: PropTypes.func.isRequired,
+  clearAccess: PropTypes.func.isRequired,
+  clearAccessErrors: PropTypes.func.isRequired,
+  loadingStatus: PropTypes.oneOf(Object.values(LOADING_STATUS)).isRequired,
+  users: PropTypes.arrayOf(libraryUserShape),
+  match: PropTypes.shape({
+    params: PropTypes.shape({
+      libraryId: PropTypes.string.isRequired,
+    }).isRequired,
+  }).isRequired,
+  history: PropTypes.shape({
+    replace: PropTypes.func.isRequired,
+  }).isRequired,
+};
+
+LibraryAccessPageContainer.defaultProps = { ...libraryAccessInitialState };
+
+export default connect(
+  selectLibraryAccess,
+  {
+    addUser,
+    clearAccessErrors,
+    clearAccess,
+    fetchLibraryDetail,
+    fetchUserList,
+  },
+)(injectIntl(withRouter(LibraryAccessPageContainer)));

--- a/src/library-authoring/library-access/LibraryAccessPage.jsx
+++ b/src/library-authoring/library-access/LibraryAccessPage.jsx
@@ -29,7 +29,7 @@ import {
   selectLibraryAccess,
 } from './data';
 // eslint-disable-next-line import/no-named-as-default
-import UserAccessContainer from './UserAccessContainer';
+import UserAccessWidgetContainer from './UserAccessWidget';
 
 
 /**
@@ -86,7 +86,7 @@ const LibraryAccessPage = ({
           <Row>
             { ((users && users.map((user) => (
               (
-                <UserAccessContainer
+                <UserAccessWidgetContainer
                   intl={intl}
                   user={user}
                   key={user.username}

--- a/src/library-authoring/library-access/UserAccessContainer.jsx
+++ b/src/library-authoring/library-access/UserAccessContainer.jsx
@@ -1,0 +1,188 @@
+/*
+Component for displaying and modifying a user's access level for a library.
+ */
+import {
+  Badge,
+  Button, Card, Col, Modal, Row,
+} from '@edx/paragon';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { faTrash } from '@fortawesome/free-solid-svg-icons';
+import React, { useContext, useState } from 'react';
+import { injectIntl, intlShape } from '@edx/frontend-platform/i18n';
+import { AppContext } from '@edx/frontend-platform/react';
+import { connect } from 'react-redux';
+import PropTypes from 'prop-types';
+import {
+  libraryUserShape, removeUserAccess, selectLibraryAccess, setUserAccess,
+} from './data';
+import { LIBRARY_ACCESS, libraryShape } from '../common/data';
+import commonMessages from '../common/messages';
+import messages from './messages';
+
+export const UserAccessContainer = ({
+  intl, library, user, multipleAdmins, setAccessLevel, removeAccess, isUser, showRemoveModal, setShowRemoveModal,
+  showDeprivModal, setShowDeprivModal, isAdmin, adminLocked,
+}) => (
+  <Col xs={12} className="py-3">
+    <Card>
+      <Card.Body>
+        <Badge className={`position-absolute ml-1 permy ${user.access_level}`}>
+          <strong>{intl.formatMessage(messages[`library.access.info.${user.access_level}`])}</strong>&nbsp;
+          <span className="font-weight-normal">{isUser && intl.formatMessage(messages['library.access.info.self'])}</span>
+        </Badge>
+        <Row className="py-3">
+          <Col xs={12} md={6}>
+            <span className="title title-2">
+              <span className="font-weight-bold">{user.username}</span>
+            </span>
+            <span className="title px-2">
+              <a href={`mailto:${user.email}`}>{user.email}</a>
+            </span>
+          </Col>
+          {isAdmin && (
+          <Col xs={12} md={6}>
+            <Row>
+              {(user.access_level === LIBRARY_ACCESS.ADMIN) && adminLocked && (
+              <Col xs={12} className="text-center text-md-right">
+                <small>{intl.formatMessage(messages['library.access.info.admin_unlock'])}</small>
+              </Col>
+              )}
+              {user.access_level === LIBRARY_ACCESS.ADMIN && multipleAdmins && (
+              <Col xs={10} className="text-left text-md-right">
+                <Button size="lg" variant="secondary" onClick={() => setShowDeprivModal(true)}>
+                  {intl.formatMessage(messages['library.access.user.remove_admin'])}
+                </Button>
+                <Modal
+                  open={showDeprivModal}
+                  title={intl.formatMessage(messages['library.access.modal.remove_admin.title'])}
+                  onClose={() => setShowDeprivModal(false)}
+                  body={(
+                    <div>
+                      <p>
+                        {intl.formatMessage(
+                          messages['library.access.modal.remove_admin.body'],
+                          { library: library.title, email: user.email },
+                        )}
+                      </p>
+                    </div>
+                  )}
+                  buttons={[
+                    <Button
+                      onClick={() => setAccessLevel(LIBRARY_ACCESS.AUTHOR).then(setShowDeprivModal(false))}
+                    >
+                      {intl.formatMessage(commonMessages['library.common.forms.button.yes'])}
+                    </Button>,
+                  ]}
+                />
+              </Col>
+              )}
+              {user.access_level === LIBRARY_ACCESS.READ && (
+              <Col xs={10} className="text-left text-md-right">
+                <Button size="lg" variant="primary" onClick={() => setAccessLevel(LIBRARY_ACCESS.AUTHOR)}>
+                  {intl.formatMessage(messages['library.access.user.add_author'])}
+                </Button>
+              </Col>
+              )}
+              {user.access_level === LIBRARY_ACCESS.AUTHOR && (
+                <>
+                  <Col xs={5} className="text-left text-md-right pl-md-1">
+                    <Button size="lg" variant="secondary" onClick={() => setAccessLevel(LIBRARY_ACCESS.READ)}>
+                      {intl.formatMessage(messages['library.access.user.remove_author'])}
+                    </Button>
+                  </Col>
+                  <Col xs={5} className="text-left text-md-right pl-md-1">
+                    <Button size="lg" variant="primary" onClick={() => setAccessLevel(LIBRARY_ACCESS.ADMIN)}>
+                      {intl.formatMessage(messages['library.access.user.add_admin'])}
+                    </Button>
+                  </Col>
+                </>
+              )}
+              {(!((user.access_level === LIBRARY_ACCESS.ADMIN) && adminLocked)) && (
+              <Col xs={2} className="text-right text-md-center">
+                <Button size="lg" variant="danger" onClick={() => setShowRemoveModal(true)}>
+                  <span className="sr-only">{intl.formatMessage(messages['library.access.user.remove_user'])}</span>
+                  <FontAwesomeIcon icon={faTrash} />
+                </Button>
+                <Modal
+                  open={showRemoveModal}
+                  title={intl.formatMessage(messages['library.access.modal.remove.title'])}
+                  onClose={() => setShowRemoveModal(false)}
+                  body={(
+                    <div>
+                      <p>
+                        {intl.formatMessage(
+                          messages['library.access.modal.remove.body'],
+                          { library: library.title, email: user.email },
+                        )}
+                      </p>
+                    </div>
+                    )}
+                  buttons={[
+                    <Button onClick={() => removeAccess()}>
+                      {intl.formatMessage(commonMessages['library.common.forms.button.yes'])}
+                    </Button>,
+                  ]}
+                />
+              </Col>
+              )}
+            </Row>
+          </Col>
+          )}
+        </Row>
+      </Card.Body>
+    </Card>
+  </Col>
+);
+export const UserAccessContainerBase = injectIntl(({
+  user, ...props
+}) => {
+  const { authenticatedUser } = useContext(AppContext);
+  const isUser = authenticatedUser.username === user.username;
+  const [showRemoveModal, setShowRemoveModal] = useState(false);
+  const [showDeprivModal, setShowDeprivModal] = useState(false);
+  const adminLocked = user.access_level === LIBRARY_ACCESS.ADMIN && !props.multipleAdmins;
+
+  const setAccessLevel = (level) => props.setUserAccess({ libraryId: props.library.id, user, level });
+
+  const removeAccess = () => props.removeUserAccess({ libraryId: props.library.id, user });
+
+  const newProps = {
+    ...props,
+    showRemoveModal,
+    setShowRemoveModal,
+    showDeprivModal,
+    setShowDeprivModal,
+    isUser,
+    user,
+    adminLocked,
+    setAccessLevel,
+    removeAccess,
+  };
+  return <UserAccessContainer {...newProps} />;
+});
+
+UserAccessContainerBase.propTypes = {
+  user: libraryUserShape.isRequired,
+  intl: intlShape.isRequired,
+  library: libraryShape.isRequired,
+  multipleAdmins: PropTypes.bool.isRequired,
+  setUserAccess: PropTypes.func.isRequired,
+  removeUserAccess: PropTypes.func.isRequired,
+};
+
+UserAccessContainer.propTypes = {
+  ...UserAccessContainerBase.propTypes,
+  isUser: PropTypes.bool.isRequired,
+  showRemoveModal: PropTypes.bool.isRequired,
+  setShowRemoveModal: PropTypes.func.isRequired,
+  showDeprivModal: PropTypes.bool.isRequired,
+  setShowDeprivModal: PropTypes.func.isRequired,
+};
+
+export default connect(
+  selectLibraryAccess,
+  {
+    setUserAccess,
+    removeUserAccess,
+  },
+)(injectIntl(UserAccessContainerBase));

--- a/src/library-authoring/library-access/UserAccessWidget.jsx
+++ b/src/library-authoring/library-access/UserAccessWidget.jsx
@@ -19,7 +19,7 @@ import { LIBRARY_ACCESS, libraryShape } from '../common/data';
 import commonMessages from '../common/messages';
 import messages from './messages';
 
-export const UserAccessContainer = ({
+export const UserAccessWidget = ({
   intl, library, user, multipleAdmins, setAccessLevel, removeAccess, isUser, showRemoveModal, setShowRemoveModal,
   showDeprivModal, setShowDeprivModal, isAdmin, adminLocked,
 }) => (
@@ -50,7 +50,7 @@ export const UserAccessContainer = ({
               {user.access_level === LIBRARY_ACCESS.ADMIN && multipleAdmins && (
               <Col xs={10} className="text-left text-md-right">
                 <Button size="lg" variant="secondary" onClick={() => setShowDeprivModal(true)}>
-                  {intl.formatMessage(messages['library.access.user.remove_admin'])}
+                  {intl.formatMessage(messages['library.access.remove_admin'])}
                 </Button>
                 <Modal
                   open={showDeprivModal}
@@ -79,7 +79,7 @@ export const UserAccessContainer = ({
               {user.access_level === LIBRARY_ACCESS.READ && (
               <Col xs={10} className="text-left text-md-right">
                 <Button size="lg" variant="primary" onClick={() => setAccessLevel(LIBRARY_ACCESS.AUTHOR)}>
-                  {intl.formatMessage(messages['library.access.user.add_author'])}
+                  {intl.formatMessage(messages['library.access.add_author'])}
                 </Button>
               </Col>
               )}
@@ -87,20 +87,26 @@ export const UserAccessContainer = ({
                 <>
                   <Col xs={5} className="text-left text-md-right pl-md-1">
                     <Button size="lg" variant="secondary" onClick={() => setAccessLevel(LIBRARY_ACCESS.READ)}>
-                      {intl.formatMessage(messages['library.access.user.remove_author'])}
+                      {intl.formatMessage(messages['library.access.remove_author'])}
                     </Button>
                   </Col>
                   <Col xs={5} className="text-left text-md-right pl-md-1">
                     <Button size="lg" variant="primary" onClick={() => setAccessLevel(LIBRARY_ACCESS.ADMIN)}>
-                      {intl.formatMessage(messages['library.access.user.add_admin'])}
+                      {intl.formatMessage(messages['library.access.add_admin'])}
                     </Button>
                   </Col>
                 </>
               )}
               {(!((user.access_level === LIBRARY_ACCESS.ADMIN) && adminLocked)) && (
               <Col xs={2} className="text-right text-md-center">
-                <Button size="lg" variant="danger" onClick={() => setShowRemoveModal(true)}>
-                  <span className="sr-only">{intl.formatMessage(messages['library.access.user.remove_user'])}</span>
+                <Button
+                  size="lg"
+                  variant="danger"
+                  onClick={() => setShowRemoveModal(true)}
+                  aria-label={
+                    intl.formatMessage(messages['library.access.remove_user'])
+                  }
+                >
                   <FontAwesomeIcon icon={faTrash} />
                 </Button>
                 <Modal
@@ -133,7 +139,7 @@ export const UserAccessContainer = ({
     </Card>
   </Col>
 );
-export const UserAccessContainerBase = injectIntl(({
+export const UserAccessWidgetContainerBase = ({
   user, ...props
 }) => {
   const { authenticatedUser } = useContext(AppContext);
@@ -158,10 +164,10 @@ export const UserAccessContainerBase = injectIntl(({
     setAccessLevel,
     removeAccess,
   };
-  return <UserAccessContainer {...newProps} />;
-});
+  return <UserAccessWidget {...newProps} />;
+};
 
-UserAccessContainerBase.propTypes = {
+UserAccessWidgetContainerBase.propTypes = {
   user: libraryUserShape.isRequired,
   intl: intlShape.isRequired,
   library: libraryShape.isRequired,
@@ -170,8 +176,8 @@ UserAccessContainerBase.propTypes = {
   removeUserAccess: PropTypes.func.isRequired,
 };
 
-UserAccessContainer.propTypes = {
-  ...UserAccessContainerBase.propTypes,
+UserAccessWidget.propTypes = {
+  ...UserAccessWidgetContainerBase.propTypes,
   isUser: PropTypes.bool.isRequired,
   showRemoveModal: PropTypes.bool.isRequired,
   setShowRemoveModal: PropTypes.func.isRequired,
@@ -179,10 +185,12 @@ UserAccessContainer.propTypes = {
   setShowDeprivModal: PropTypes.func.isRequired,
 };
 
-export default connect(
+const UserAccessWidgetContainer = connect(
   selectLibraryAccess,
   {
     setUserAccess,
     removeUserAccess,
   },
-)(injectIntl(UserAccessContainerBase));
+)(injectIntl(UserAccessWidgetContainerBase));
+
+export default UserAccessWidgetContainer;

--- a/src/library-authoring/library-access/data/api.js
+++ b/src/library-authoring/library-access/data/api.js
@@ -1,0 +1,68 @@
+import { ensureConfig, getConfig } from '@edx/frontend-platform';
+import { getAuthenticatedHttpClient } from '@edx/frontend-platform/auth';
+
+ensureConfig([
+  'STUDIO_BASE_URL',
+], 'Library API service');
+
+function setupRequest() {
+  return { client: getAuthenticatedHttpClient(), baseUrl: getConfig().STUDIO_BASE_URL };
+}
+
+/* eslint-disable-next-line import/prefer-default-export */
+export async function fetchUsers(libraryId) {
+  const { client, baseUrl } = setupRequest();
+  const response = await client.get(
+    `${baseUrl}/api/libraries/v2/${libraryId}/team/`,
+  ).catch((error) => {
+    /* Normalize error data. */
+    const apiError = Object.create(error);
+    apiError.message = null;
+    apiError.fields = JSON.parse(error.customAttributes.httpErrorResponseData);
+    throw apiError;
+  });
+  return response.data;
+}
+
+export async function addUserToLibrary({ libraryId, data }) {
+  const { client, baseUrl } = setupRequest();
+  const response = await client.post(
+    `${baseUrl}/api/libraries/v2/${libraryId}/team/`,
+    data,
+  ).catch((error) => {
+    /* Normalize error data. */
+    const apiError = Object.create(error);
+    apiError.message = null;
+    apiError.fields = JSON.parse(error.customAttributes.httpErrorResponseData);
+    throw apiError;
+  });
+  return response.data;
+}
+
+export async function setUserAccessLevel({ libraryId, user, level }) {
+  const { client, baseUrl } = setupRequest();
+  const response = await client.put(
+    `${baseUrl}/api/libraries/v2/${libraryId}/team/user/${user.username}/`,
+    { access_level: level },
+  ).catch((error) => {
+    /* Normalize error data. */
+    const apiError = Object.create(error);
+    apiError.message = null;
+    apiError.fields = JSON.parse(error.customAttributes.httpErrorResponseData);
+    throw apiError;
+  });
+  return response.data;
+}
+
+export async function removeUserFromLibrary({ libraryId, user }) {
+  const { client, baseUrl } = setupRequest();
+  return client.delete(
+    `${baseUrl}/api/libraries/v2/${libraryId}/team/user/${user.username}/`,
+  ).catch((error) => {
+    /* Normalize error data. */
+    const apiError = Object.create(error);
+    apiError.message = null;
+    apiError.fields = JSON.parse(error.customAttributes.httpErrorResponseData);
+    throw apiError;
+  });
+}

--- a/src/library-authoring/library-access/data/index.js
+++ b/src/library-authoring/library-access/data/index.js
@@ -1,0 +1,4 @@
+export { default as selectLibraryAccess } from './selectors';
+export * from './slice';
+export * from './thunks';
+export * from './shapes';

--- a/src/library-authoring/library-access/data/selectors.js
+++ b/src/library-authoring/library-access/data/selectors.js
@@ -1,0 +1,17 @@
+import { createSelector } from 'reselect';
+import { libraryAccessStoreName as storeName } from './slice';
+import { selectLibraryDetail } from '../../library-detail/data';
+
+const stateSelector = state => ({ ...state[storeName] });
+
+const selectLibraryAccess = createSelector(
+  stateSelector,
+  selectLibraryDetail,
+  (editState, libraryState) => ({
+    ...editState,
+    library: libraryState.library,
+    loadingStatus: libraryState.status,
+  }),
+);
+
+export default selectLibraryAccess;

--- a/src/library-authoring/library-access/data/shapes.js
+++ b/src/library-authoring/library-access/data/shapes.js
@@ -1,0 +1,9 @@
+import PropTypes from 'prop-types';
+import { LIBRARY_ACCESS } from '../../common/data';
+
+// eslint-disable-next-line import/prefer-default-export
+export const libraryUserShape = PropTypes.shape({
+  username: PropTypes.string.isRequired,
+  email: PropTypes.string.isRequired,
+  access_level: PropTypes.oneOf([...Object.values(LIBRARY_ACCESS)]),
+});

--- a/src/library-authoring/library-access/data/slice.js
+++ b/src/library-authoring/library-access/data/slice.js
@@ -14,44 +14,47 @@ export const libraryAccessInitialState = {
   submissionStatus: SUBMISSION_STATUS.UNSUBMITTED,
 };
 
+export const reducers = {
+  libraryAccessRequest: (state) => {
+    state.status = LOADING_STATUS.LOADING;
+  },
+  libraryAccessFailed: (state, { payload }) => {
+    state.errorMessage = payload.errorMessage;
+    state.errorFields = payload.errorFields;
+    state.status = SUBMISSION_STATUS.FAILED;
+  },
+  libraryAccessClearError: (state) => {
+    state.errorMessage = null;
+    state.errorFields = null;
+    state.status = SUBMISSION_STATUS.UNSUBMITTED;
+  },
+  libraryAccessReset: (state) => {
+    state.errorMessage = libraryAccessInitialState.errorMessage;
+    state.errorFields = libraryAccessInitialState.errorFields;
+    state.status = libraryAccessInitialState.status;
+  },
+  libraryAddUser: (state, { payload }) => {
+    state.users.unshift(payload.user);
+  },
+  libraryRemoveUser: (state, { payload }) => {
+    state.users = state.users.filter((user) => user.username !== payload.user.username);
+  },
+  libraryUpdateUser: (state, { payload }) => {
+    const existing = state.users.filter((user) => user.username === payload.user.username)[0];
+    Object.assign(existing, payload.user);
+  },
+  libraryUsersSuccess: (state, { payload }) => {
+    state.users = payload.users;
+  },
+  libraryAccessClear: (state) => {
+    Object.assign(state, { ...libraryAccessInitialState });
+  },
+};
+
 const slice = createSlice({
   name: libraryAccessStoreName,
   initialState: libraryAccessInitialState,
-  reducers: {
-    libraryAccessRequest: (state) => {
-      state.status = LOADING_STATUS.LOADING;
-    },
-    libraryAccessFailed: (state, { payload }) => {
-      state.errorMessage = payload.errorMessage;
-      state.errorFields = payload.errorFields;
-      state.status = SUBMISSION_STATUS.FAILED;
-    },
-    libraryAccessClearError: (state) => {
-      state.errorMessage = null;
-      state.errorFields = null;
-    },
-    libraryAccessReset: (state) => {
-      state.errorMessage = libraryAccessInitialState.errorMessage;
-      state.errorFields = libraryAccessInitialState.errorFields;
-      state.status = libraryAccessInitialState.status;
-    },
-    libraryAddUser: (state, { payload }) => {
-      state.users.unshift(payload.user);
-    },
-    libraryRemoveUser: (state, { payload }) => {
-      state.users = state.users.filter((user) => user.username !== payload.user.username);
-    },
-    libraryUpdateUser: (state, { payload }) => {
-      const existing = state.users.filter((user) => user.username === payload.user.username)[0];
-      Object.assign(existing, payload.user);
-    },
-    libraryUsersSuccess: (state, { payload }) => {
-      state.users = payload.users;
-    },
-    libraryAccessClear: (state) => {
-      Object.assign(state, { ...libraryAccessInitialState });
-    },
-  },
+  reducers,
 });
 
 export const libraryAccessActions = slice.actions;

--- a/src/library-authoring/library-access/data/slice.js
+++ b/src/library-authoring/library-access/data/slice.js
@@ -1,0 +1,58 @@
+/* eslint-disable no-param-reassign */
+import { createSlice } from '@reduxjs/toolkit';
+
+import { LOADING_STATUS, SUBMISSION_STATUS } from '../../common';
+
+export const libraryAccessStoreName = 'libraryAccess';
+
+export const libraryAccessInitialState = {
+  library: null,
+  users: null,
+  errorMessage: null,
+  errorFields: null,
+  loadingStatus: LOADING_STATUS.LOADING,
+  submissionStatus: SUBMISSION_STATUS.UNSUBMITTED,
+};
+
+const slice = createSlice({
+  name: libraryAccessStoreName,
+  initialState: libraryAccessInitialState,
+  reducers: {
+    libraryAccessRequest: (state) => {
+      state.status = LOADING_STATUS.LOADING;
+    },
+    libraryAccessFailed: (state, { payload }) => {
+      state.errorMessage = payload.errorMessage;
+      state.errorFields = payload.errorFields;
+      state.status = SUBMISSION_STATUS.FAILED;
+    },
+    libraryAccessClearError: (state) => {
+      state.errorMessage = null;
+      state.errorFields = null;
+    },
+    libraryAccessReset: (state) => {
+      state.errorMessage = libraryAccessInitialState.errorMessage;
+      state.errorFields = libraryAccessInitialState.errorFields;
+      state.status = libraryAccessInitialState.status;
+    },
+    libraryAddUser: (state, { payload }) => {
+      state.users.unshift(payload.user);
+    },
+    libraryRemoveUser: (state, { payload }) => {
+      state.users = state.users.filter((user) => user.username !== payload.user.username);
+    },
+    libraryUpdateUser: (state, { payload }) => {
+      const existing = state.users.filter((user) => user.username === payload.user.username)[0];
+      Object.assign(existing, payload.user);
+    },
+    libraryUsersSuccess: (state, { payload }) => {
+      state.users = payload.users;
+    },
+    libraryAccessClear: (state) => {
+      Object.assign(state, { ...libraryAccessInitialState });
+    },
+  },
+});
+
+export const libraryAccessActions = slice.actions;
+export const libraryAccessReducer = slice.reducer;

--- a/src/library-authoring/library-access/data/specs/slice.spec.js
+++ b/src/library-authoring/library-access/data/specs/slice.spec.js
@@ -1,0 +1,75 @@
+import { libraryAccessInitialState, reducers } from '../slice';
+import { LOADING_STATUS, SUBMISSION_STATUS } from '../../../common/data';
+import { userFactoryLine } from '../../../common/specs/factories';
+import { makeN } from '../../../common/specs/helpers';
+
+describe('library-access/data/slice.js', () => {
+  it('Marks the loading state', () => {
+    const state = {};
+    reducers.libraryAccessRequest(state);
+    expect(state.status).toBe(LOADING_STATUS.LOADING);
+  });
+  it('Marks a failure state with errors', () => {
+    const state = {};
+    reducers.libraryAccessFailed(
+      state, { payload: { errorMessage: 'It borked.', errorFields: { email: 'Phony email.' } } },
+    );
+    expect(state.status).toBe(LOADING_STATUS.FAILED);
+    expect(state.errorMessage).toBe('It borked.');
+    expect(state.errorFields).toEqual({ email: 'Phony email.' });
+  });
+  it('Clears error state', () => {
+    const state = {
+      status: SUBMISSION_STATUS.FAILED,
+      errorMessage: 'It borked.',
+      errorFields: { email: 'That ISP doesn\t even exist anymore!' },
+    };
+    reducers.libraryAccessClearError(state);
+    expect(state.status).toBe(SUBMISSION_STATUS.UNSUBMITTED);
+    expect(state.errorFields).toBe(null);
+    expect(state.errorMessage).toBe(null);
+  });
+  it('Adds a user to the user list.', () => {
+    const state = {
+      users: makeN(userFactoryLine(), 5),
+    };
+    const [user] = userFactoryLine();
+    reducers.libraryAddUser(state, { payload: { user } });
+    expect(state.users.length).toBe(6);
+    expect(state.users[0].username).toEqual(user.username);
+  });
+  it('Removes a user from the user list.', () => {
+    const state = {
+      users: makeN(userFactoryLine(), 5),
+    };
+    const user = state.users[3];
+    reducers.libraryRemoveUser(state, { payload: { user } });
+    expect(state.users.length).toBe(4);
+    expect(state.users.map(leftBehind => leftBehind.username).includes(user.username)).toBe(false);
+  });
+  it('Updates a user', () => {
+    const state = {
+      users: makeN(userFactoryLine(), 5),
+    };
+    const oldUser = state.users[3];
+    const user = { ...oldUser };
+    user.email = 'new_email@example.com';
+    reducers.libraryUpdateUser(state, { payload: { user } });
+    expect(state.users[3].email).toBe('new_email@example.com');
+  });
+  it('Sets the userlist', () => {
+    const state = { users: null };
+    const users = makeN(userFactoryLine(), 3);
+    reducers.libraryUsersSuccess(state, { payload: { users } });
+    expect(users).toEqual(state.users);
+  });
+  it('Resets the state', () => {
+    const state = { ...libraryAccessInitialState };
+    // eslint-disable-next-line no-restricted-syntax
+    for (const key of Object.keys(state)) {
+      state[key] = 'Bogus value';
+    }
+    reducers.libraryAccessClear(state);
+    expect(state).toEqual(libraryAccessInitialState);
+  });
+});

--- a/src/library-authoring/library-access/data/thunks.js
+++ b/src/library-authoring/library-access/data/thunks.js
@@ -1,0 +1,58 @@
+import { logError } from '@edx/frontend-platform/logging';
+import { libraryAccessActions as actions } from './slice';
+import * as api from './api';
+
+/* eslint-disable-next-line import/prefer-default-export */
+export const fetchUserList = ({ libraryId }) => async (dispatch) => {
+  try {
+    const users = await api.fetchUsers(libraryId);
+    dispatch(actions.libraryUsersSuccess({ users }));
+  } catch (error) {
+    dispatch(actions.libraryAccessFailed({ errorMessage: error.message }));
+    logError(error);
+  }
+};
+
+export const addUser = ({ libraryId, data }) => async (dispatch) => {
+  try {
+    dispatch(actions.libraryAccessRequest());
+    const newUser = await api.addUserToLibrary({ libraryId, data });
+    dispatch(actions.libraryAddUser({ user: newUser }));
+    dispatch(actions.libraryAccessClearError());
+  } catch (error) {
+    dispatch(actions.libraryAccessFailed({ errorMessage: error.message, errorFields: error.fields }));
+    logError(error);
+    // Don't want to return this as successful, as the form will clear out info if we do.
+    throw error;
+  }
+};
+
+export const setUserAccess = ({ libraryId, user, level }) => async (dispatch) => {
+  try {
+    dispatch(actions.libraryAccessRequest());
+    const updatedUser = await api.setUserAccessLevel({ libraryId, user, level });
+    dispatch(actions.libraryUpdateUser({ user: updatedUser }));
+  } catch (error) {
+    dispatch(actions.libraryAccessFailed({ errorMessage: error.message, errorFields: error.fields }));
+    logError(error);
+  }
+};
+
+export const removeUserAccess = ({ libraryId, user }) => async (dispatch) => {
+  try {
+    dispatch(actions.libraryAccessRequest());
+    await api.removeUserFromLibrary({ libraryId, user });
+    dispatch(actions.libraryRemoveUser({ user }));
+  } catch (error) {
+    dispatch(actions.libraryAccessFailed({ errorMessage: error.message }));
+    logError(error);
+  }
+};
+
+export const clearAccessErrors = () => async (dispatch) => {
+  dispatch(actions.libraryAccessClearError());
+};
+
+export const clearAccess = () => async (dispatch) => {
+  dispatch(actions.libraryAccessClear());
+};

--- a/src/library-authoring/library-access/index.js
+++ b/src/library-authoring/library-access/index.js
@@ -1,0 +1,2 @@
+export { default as LibraryAccessPage } from './LibraryAccessPage'; // eslint-disable-line import/prefer-default-export
+export * from './data';

--- a/src/library-authoring/library-access/index.scss
+++ b/src/library-authoring/library-access/index.scss
@@ -1,0 +1,43 @@
+.perm-badge {
+  position: absolute;
+  top: -1.25rem;
+  margin-left: .5rem;
+  padding: .25rem .75rem .25rem .75rem;
+  color: white;
+  font-size: 70%;
+  text-transform: uppercase;
+  &.admin {
+    background-color: $pink;
+  }
+  &.author {
+    background-color: $blue;
+  }
+  &.read {
+    background-color: $yellow-d1;
+  }
+}
+
+.permy {
+  top: -1rem;
+  color: $white;
+  &.admin {
+    background-color: $pink;
+  }
+  &.author {
+    background-color: $blue;
+  }
+  &.read {
+    background-color: $yellow-d1;
+  }
+}
+
+.card-title {
+  font-size: 150%;
+}
+
+.library-access-wrapper .form-create {
+  border: none;
+  &:hover {
+    box-shadow: none;
+  }
+}

--- a/src/library-authoring/library-access/messages.js
+++ b/src/library-authoring/library-access/messages.js
@@ -1,0 +1,170 @@
+import { defineMessages } from '@edx/frontend-platform/i18n';
+
+const messages = defineMessages({
+  'library.access.loading.message': {
+    id: 'library.access.loading.message',
+    defaultMessage: 'Loading...',
+    description: 'Message when data is being loaded',
+  },
+  'library.access.page.parent_heading': {
+    id: 'library.access.page.parent_heading',
+    defaultMessage: 'Settings',
+    description: 'Small text heading above the main title for the access page',
+  },
+  'library.access.page.heading': {
+    id: 'library.access.page.heading',
+    defaultMessage: 'User Access',
+    description: 'Title of user access settings page',
+  },
+  'library.access.aside.title': {
+    id: 'library.access.aside.title',
+    defaultMessage: 'Library Access Roles',
+    description: 'Header for the aside description of the access page.',
+  },
+  'library.access.aside.text.first': {
+    id: 'library.access.aside.text.first',
+    defaultMessage: 'There are three access roles for libraries: User, Staff, and Admin.',
+    description: 'The first paragraph of detail text on user access roles.',
+  },
+  'library.access.aside.text.second': {
+    id: 'library.access.aside.text.second',
+    defaultMessage: 'Library Users can view library content and can reference or use library components in their '
+      + 'courses, but they cannot edit the contents of a library.',
+    description: 'The second paragraph of detail text on user access roles.',
+  },
+  'library.access.aside.text.third': {
+    id: 'library.access.aside.text.third',
+    defaultMessage: 'Library Staff are content co-authors. They have full editing privileges on the contents '
+      + 'of a library.',
+    description: 'The third paragraph of detail text on user access roles.',
+  },
+  'library.access.aside.text.fourth': {
+    id: 'library.access.aside.text.fourth',
+    defaultMessage: 'Library Admins have full editing privileges and can also add and remove other team members. '
+      + 'There must be at least one user with the Admin role in a library.',
+    description: 'The fourth paragraph of detail text on user access roles.',
+  },
+  'library.access.new.user': {
+    id: 'library.access.new.user',
+    defaultMessage: 'New Team Member',
+    description: 'Button text for adding a new user to the library access roles.',
+  },
+  'library.access.well.title': {
+    id: 'library.access.well.title',
+    defaultMessage: 'Add More Users to This Library',
+    description: 'Title for the "call to action" well on the bottom of the page.',
+  },
+  'library.access.well.text': {
+    id: 'library.access.well.text',
+    defaultMessage: 'Grant other members of your course team access to this library. New library users must have an '
+      + 'active Studio account.',
+    description: 'Text for the "call to action" well on the bottom of the page.',
+  },
+  'library.access.well.button': {
+    id: 'library.access.well.button',
+    defaultMessage: 'Add a New User',
+    description: 'Text for the button in the "call to action" well on the bottom of the page.',
+  },
+  'library.access.form.title': {
+    id: 'library.access.form.title',
+    defaultMessage: 'Grant Access to this Library',
+    description: 'Help text for the email field.',
+  },
+  'library.access.form.email.help': {
+    id: 'library.access.form.email.help',
+    defaultMessage: 'Provide the email address of the user you want to add',
+    description: 'Help text for the email field.',
+  },
+  'library.access.form.email.label': {
+    id: 'library.access.form.email.label',
+    defaultMessage: 'Email',
+    description: 'Label for the email field.',
+  },
+  'library.access.form.email.placeholder': {
+    id: 'library.access.form.email.placeholder',
+    defaultMessage: 'example: username@domain.com',
+    description: 'Placeholder text for the email field.',
+  },
+  'library.access.form.button.submit': {
+    id: 'library.access.form.button.submit',
+    defaultMessage: 'Submit',
+    description: 'Submit button text',
+  },
+  'library.access.form.button.submitting': {
+    id: 'library.access.form.button.submitting',
+    defaultMessage: 'Submitting...',
+    description: 'Submit button text when currently submitting',
+  },
+  'library.access.info.admin_unlock': {
+    id: 'library.access.info.admin_unlock',
+    defaultMessage: 'Promote another member to Admin to remove this user\'s admin rights',
+    description: 'Instructions given for removing your own admin privileges.',
+  },
+  'library.access.info.self': {
+    id: 'library.access.info.self',
+    defaultMessage: 'You!',
+    description: 'Short indicator that the user being viewed is the viewer.',
+  },
+  'library.access.info.admin': {
+    id: 'library.access.info.admin',
+    defaultMessage: 'Admin',
+    description: 'Label for the admin access level.',
+  },
+  'library.access.info.author': {
+    id: 'library.access.info.author',
+    defaultMessage: 'Author',
+    description: 'Label for the author access level.',
+  },
+  'library.access.info.read': {
+    id: 'library.access.info.read',
+    defaultMessage: 'Read Only',
+    description: 'Label for the read only access level.',
+  },
+  'library.access.user.add_admin': {
+    id: 'library.access.user.add_admin',
+    defaultMessage: 'Add Admin Access',
+    description: 'Label for button that grants a user admin access.',
+  },
+  'library.access.user.remove_admin': {
+    id: 'library.access.user.remove_admin',
+    defaultMessage: 'Remove Admin Access',
+    description: 'Label for button that removes a user\'s admin access.',
+  },
+  'library.access.user.add_author': {
+    id: 'library.access.user.add_author',
+    defaultMessage: 'Add Author Access',
+    description: 'Label for button that grants a user author access.',
+  },
+  'library.access.user.remove_author': {
+    id: 'library.access.user.remove_author',
+    defaultMessage: 'Remove Author Access',
+    description: 'Label for button that removes a user\'s author access level.',
+  },
+  'library.access.user.remove_user': {
+    id: 'library.access.user.remove_user',
+    defaultMessage: 'Remove user',
+    description: 'Label for button that removes a user from a library entirely. Screen-reader only.',
+  },
+  'library.access.modal.remove.title': {
+    id: 'library.access.modal.remove.title',
+    defaultMessage: 'Are you sure?',
+    description: 'Title for user removal confirmation modal',
+  },
+  'library.access.modal.remove.body': {
+    id: 'library.access.modal.remove.body',
+    defaultMessage: 'Are you sure you want to delete {email} from the library "{library}"?',
+    description: 'Body of user removal confirmation modal.',
+  },
+  'library.access.modal.remove_admin.title': {
+    id: 'library.access.modal.remove_admin.title',
+    defaultMessage: 'Are you sure?',
+    description: 'Title for user admin privilege removal confirmation modal',
+  },
+  'library.access.modal.remove_admin.body': {
+    id: 'library.access.modal.remove_admin.body',
+    defaultMessage: 'Are you sure you want to revoke admin privileges for {email} from the library "{library}"?',
+    description: 'Body of user admin privilege removal confirmation modal.',
+  },
+});
+
+export default messages;

--- a/src/library-authoring/library-access/messages.js
+++ b/src/library-authoring/library-access/messages.js
@@ -120,30 +120,30 @@ const messages = defineMessages({
     defaultMessage: 'Read Only',
     description: 'Label for the read only access level.',
   },
-  'library.access.user.add_admin': {
-    id: 'library.access.user.add_admin',
+  'library.access.add_admin': {
+    id: 'library.access.add_admin',
     defaultMessage: 'Add Admin Access',
     description: 'Label for button that grants a user admin access.',
   },
-  'library.access.user.remove_admin': {
-    id: 'library.access.user.remove_admin',
+  'library.access.remove_admin': {
+    id: 'library.access.remove_admin',
     defaultMessage: 'Remove Admin Access',
     description: 'Label for button that removes a user\'s admin access.',
   },
-  'library.access.user.add_author': {
-    id: 'library.access.user.add_author',
+  'library.access.add_author': {
+    id: 'library.access.add_author',
     defaultMessage: 'Add Author Access',
     description: 'Label for button that grants a user author access.',
   },
-  'library.access.user.remove_author': {
-    id: 'library.access.user.remove_author',
+  'library.access.remove_author': {
+    id: 'library.access.remove_author',
     defaultMessage: 'Remove Author Access',
     description: 'Label for button that removes a user\'s author access level.',
   },
-  'library.access.user.remove_user': {
-    id: 'library.access.user.remove_user',
+  'library.access.remove_user': {
+    id: 'library.access.remove_user',
     defaultMessage: 'Remove user',
-    description: 'Label for button that removes a user from a library entirely. Screen-reader only.',
+    description: 'Aria label for button that removes a user\'s access entirely.',
   },
   'library.access.modal.remove.title': {
     id: 'library.access.modal.remove.title',

--- a/src/library-authoring/library-access/specs/LibraryAccessForm.spec.jsx
+++ b/src/library-authoring/library-access/specs/LibraryAccessForm.spec.jsx
@@ -1,0 +1,54 @@
+import { injectIntl } from '@edx/frontend-platform/i18n';
+import React from 'react';
+import {
+  fireEvent, getByLabelText, getByRole, getByText, waitFor,
+} from '@testing-library/dom';
+import { RawLibraryAccessFormContainer } from '../LibraryAccessForm';
+import { ctxRender, immediate, mocksFromNames } from '../../common/specs/helpers';
+import { libraryFactory, userFactory } from '../../common/specs/factories';
+import { LIBRARY_ACCESS } from '../../common/data';
+
+const LibraryAccessFormContainer = injectIntl(RawLibraryAccessFormContainer);
+
+function commonMocks() {
+  return mocksFromNames(['clearAccessErrors', 'addUser', 'setShowAdd']);
+}
+
+describe('<LibraryAccessForm />', () => {
+  it('Renders an error for the email field', () => {
+    const library = libraryFactory();
+    const props = { library, errorFields: { email: 'Too difficult to remember.' }, ...commonMocks() };
+    const { container } = ctxRender(<LibraryAccessFormContainer {...props} />);
+    expect(getByText(container, /Too difficult/)).toBeTruthy();
+  });
+  it('Submits and adds a new user.', async () => {
+    const library = libraryFactory();
+    const props = { library, ...commonMocks() };
+    const { addUser } = props;
+    const user = userFactory();
+    addUser.mockImplementation(() => immediate(user));
+    const { container } = ctxRender(<LibraryAccessFormContainer {...props} />);
+    const emailField = getByLabelText(container, 'Email');
+    fireEvent.change(emailField, { target: { value: 'boop@beep.com' } });
+    const submitButton = getByRole(container, 'button', { name: /Submit/ });
+    fireEvent.click(submitButton);
+    await waitFor(() => expect(addUser).toHaveBeenCalledWith({
+      libraryId: library.id, data: { email: 'boop@beep.com', access_level: LIBRARY_ACCESS.READ },
+    }));
+    expect(emailField.value).toBe('');
+  });
+  it('Closes out', () => {
+    const library = libraryFactory();
+    const props = { library, ...commonMocks() };
+    const { setShowAdd } = props;
+    const { container } = ctxRender(
+      <LibraryAccessFormContainer
+        {...props}
+      />,
+      {},
+    );
+    const button = getByRole(container, 'button', { name: /Cancel/ });
+    fireEvent.click(button);
+    expect(setShowAdd).toHaveBeenCalledWith(false);
+  });
+});

--- a/src/library-authoring/library-access/specs/UserAccessContainer.spec.jsx
+++ b/src/library-authoring/library-access/specs/UserAccessContainer.spec.jsx
@@ -1,0 +1,221 @@
+import * as React from 'react';
+import { screen } from '@testing-library/react';
+import { injectIntl } from '@edx/frontend-platform/i18n';
+import {
+  getByRole, getByText, queryAllByRole, queryAllByText,
+} from '@testing-library/dom';
+import { UserAccessWidgetContainerBase } from '../UserAccessWidget';
+import { ctxRender, mocksFromNames } from '../../common/specs/helpers';
+import { libraryFactoryLine, userFactoryLine } from '../../common/specs/factories';
+import { LIBRARY_ACCESS } from '../../common/data';
+
+function commonMocks() {
+  return mocksFromNames([
+    'setUserAccess', 'removeUserAccess',
+  ]);
+}
+
+const UserAccessWidgetContainer = injectIntl(UserAccessWidgetContainerBase);
+
+describe('<UserAccessWidgetContainer />', () => {
+  [
+    [LIBRARY_ACCESS.READ, 'Read Only'],
+    [LIBRARY_ACCESS.ADMIN, 'Admin'],
+    [LIBRARY_ACCESS.AUTHOR, 'Author'],
+  ].forEach(([accessLevel, text]) => {
+    it(`Should render a badge labeled ${text} when the target user's access level is ${accessLevel}.`, async () => {
+      const [library] = libraryFactoryLine();
+      // userId doesn't exist on users pulled from the team listings, but it does exist on authenticated users.
+      const [user, currentUser] = userFactoryLine([{ access_level: accessLevel }, { userId: 3 }]);
+      const props = {
+        library, user, multipleAdmins: false, ...commonMocks(),
+      };
+      ctxRender(
+        <UserAccessWidgetContainer
+          {...props}
+        />,
+        { authenticatedUser: currentUser },
+      );
+      const badge = screen.getByText(text);
+      expect(badge).toBeTruthy();
+    });
+  });
+
+  [
+    [true, LIBRARY_ACCESS.ADMIN, false, false],
+    [true, LIBRARY_ACCESS.ADMIN, true, true],
+    [true, LIBRARY_ACCESS.AUTHOR, true, false],
+    [true, LIBRARY_ACCESS.AUTHOR, false, false],
+    [true, LIBRARY_ACCESS.READ, true, false],
+    [true, LIBRARY_ACCESS.READ, false, false],
+    [false, LIBRARY_ACCESS.ADMIN, true, false],
+    [false, LIBRARY_ACCESS.ADMIN, false, false],
+  ].forEach(([isAdmin, accessLevel, multipleAdmins, buttonsShown]) => {
+    let testName = 'The admin privilege management buttons are ';
+    if (!buttonsShown) {
+      testName += 'not ';
+    }
+    testName += 'shown when the viewer is ';
+    if (!isAdmin) {
+      testName += 'not ';
+    }
+    testName += `an admin and the subject's access level is ${accessLevel} and there are `;
+    if (!multipleAdmins) {
+      testName += 'multiple admins.';
+    }
+
+    it(testName, async () => {
+      const [library] = libraryFactoryLine();
+      const [currentUser, targetUser] = userFactoryLine([{}, { access_level: accessLevel }]);
+      const props = {
+        library, user: targetUser, multipleAdmins, isAdmin, ...commonMocks(),
+      };
+      const { container } = ctxRender(
+        <UserAccessWidgetContainer
+          {...props}
+        />,
+        { authenticatedUser: currentUser },
+      );
+      if (buttonsShown) {
+        const removeButton = getByRole(container, 'button', { name: /Remove Admin/ });
+        expect(removeButton).toBeTruthy();
+      } else {
+        const buttonList = queryAllByRole(container, 'button', { name: /Remove Admin/ });
+        expect(buttonList.length).toBe(0);
+        if (isAdmin && targetUser.access_level === LIBRARY_ACCESS.ADMIN) {
+          expect(getByText(container, /Promote another member/)).toBeTruthy();
+        } else {
+          expect(queryAllByText(container, /Promote another member/).length).toBe(0);
+        }
+      }
+    });
+  });
+
+  [
+    [true, LIBRARY_ACCESS.ADMIN, false],
+    [true, LIBRARY_ACCESS.AUTHOR, true],
+    [true, LIBRARY_ACCESS.READ, false],
+    [false, LIBRARY_ACCESS.AUTHOR, false],
+  ].forEach(([isAdmin, accessLevel, buttonsShown]) => {
+    let testName = 'The staff management buttons are ';
+    if (!buttonsShown) {
+      testName += 'not ';
+    }
+    testName += 'visible when the viewer is ';
+    if (!isAdmin) {
+      testName += 'not ';
+    }
+    testName += `an admin and the subject's current access_level is ${accessLevel}.`;
+
+    it(testName, async () => {
+      const [library] = libraryFactoryLine();
+      const [currentUser, targetUser] = userFactoryLine([{}, { access_level: accessLevel }]);
+      const props = {
+        library, user: targetUser, multipleAdmins: false, isAdmin, ...commonMocks(),
+      };
+      const { container } = ctxRender(
+        <UserAccessWidgetContainer
+          {...props}
+        />,
+        { authenticatedUser: currentUser },
+      );
+      if (buttonsShown) {
+        const removeButton = getByRole(container, 'button', { name: /Remove Author/ });
+        expect(removeButton).toBeTruthy();
+        const addButton = getByRole(container, 'button', { name: /Add Admin/ });
+        expect(addButton).toBeTruthy();
+      } else {
+        const buttonList = queryAllByRole(container, 'button', { name: /(Remove Author|Add Admin)/ });
+        expect(buttonList.length).toBe(0);
+      }
+    });
+  });
+
+  [
+    [true, LIBRARY_ACCESS.ADMIN, false],
+    [true, LIBRARY_ACCESS.AUTHOR, false],
+    [true, LIBRARY_ACCESS.READ, true],
+    [false, LIBRARY_ACCESS.READ, false],
+  ].forEach(([isAdmin, accessLevel, buttonShown]) => {
+    let testName = 'The add author privileges button is ';
+    if (!buttonShown) {
+      testName += 'not ';
+    }
+    testName += 'visible if the viewer is ';
+    if (!isAdmin) {
+      testName += 'not ';
+    }
+    testName += `an admin and the subject's access level is ${accessLevel}.`;
+
+    it(testName, async () => {
+      const [library] = libraryFactoryLine();
+      const [currentUser, targetUser] = userFactoryLine([{}, { access_level: accessLevel }]);
+      const props = {
+        library, user: targetUser, multipleAdmins: false, isAdmin, ...commonMocks(),
+      };
+      const { container } = ctxRender(
+        <UserAccessWidgetContainer
+          {...props}
+        />,
+        { authenticatedUser: currentUser },
+      );
+      const buttonList = queryAllByRole(container, 'button', { name: /Add Author/ });
+      if (buttonShown) {
+        expect(buttonList.length).toBe(1);
+      } else {
+        expect(buttonList.length).toBe(0);
+      }
+    });
+  });
+
+  [
+    [true, LIBRARY_ACCESS.ADMIN, false, false],
+    [true, LIBRARY_ACCESS.ADMIN, true, true],
+    [true, LIBRARY_ACCESS.AUTHOR, true, true],
+    [true, LIBRARY_ACCESS.AUTHOR, false, true],
+    [true, LIBRARY_ACCESS.READ, true, true],
+    [true, LIBRARY_ACCESS.READ, false, true],
+    [false, LIBRARY_ACCESS.ADMIN, true, false],
+    [false, LIBRARY_ACCESS.ADMIN, false, false],
+    [false, LIBRARY_ACCESS.AUTHOR, true, false],
+    [false, LIBRARY_ACCESS.AUTHOR, false, false],
+    [false, LIBRARY_ACCESS.READ, true, false],
+    [false, LIBRARY_ACCESS.READ, false, false],
+  ].forEach(([isAdmin, accessLevel, multipleAdmins, buttonShown]) => {
+    let testName = 'The button for removing a user is ';
+    if (buttonShown) {
+      testName += 'present';
+    } else {
+      testName += 'not present';
+    }
+    testName += ' when the viewer is ';
+    if (!isAdmin) {
+      testName += 'not ';
+    }
+    testName += 'an admin and there are ';
+    if (!multipleAdmins) {
+      testName += ' not ';
+    }
+    testName += 'multiple admins in a library.';
+
+    it(testName, async () => {
+      const [library] = libraryFactoryLine();
+      const [currentUser, targetUser] = userFactoryLine([{}, { access_level: accessLevel }]);
+      const props = {
+        library, user: targetUser, multipleAdmins, isAdmin, ...commonMocks(),
+      };
+      const { container } = ctxRender(
+        <UserAccessWidgetContainer
+          {...props}
+        />,
+        { authenticatedUser: currentUser },
+      );
+      const buttonList = queryAllByRole(container, 'button', { name: /Remove user/ });
+      if (buttonShown) {
+        expect(buttonList.length).toBe(1);
+      } else {
+        expect(buttonList.length).toBe(0);
+      }
+    });
+  });
+});

--- a/src/library-authoring/library-detail/LibraryPage.jsx
+++ b/src/library-authoring/library-detail/LibraryPage.jsx
@@ -36,6 +36,16 @@ class LibraryPage extends React.Component {
     this.props.fetchLibraryDetail({ libraryId });
   }
 
+  componentDidUpdate(prevProps) {
+    const oldBlockTypes = (prevProps.library && prevProps.library.blockTypes) || [];
+    const newBlockTypes = (this.props.library && this.props.library.blockTypes) || [];
+    // Identity check is good enough here. In all current scenarios it should have the same effect as deep equality
+    // checking. Might change this if we suddenly allow switching libraries in place from this page.
+    if ((oldBlockTypes !== newBlockTypes) && newBlockTypes.length) {
+      this.updateBlockDefault();
+    }
+  }
+
   handleCommitChanges = () => {
     this.props.commitLibraryChanges({ libraryId: this.props.library.id });
   }
@@ -72,6 +82,16 @@ class LibraryPage extends React.Component {
       this.addComponentRef.current.scrollIntoView({
         behaviour: 'smooth',
       });
+    }
+  }
+
+  updateBlockDefault() {
+    // The default block type is 'html', but this will break the form if we're in a video or problem library.
+    // In the case we're in one of those, the server should only return one valid block type, which we can then set.
+    const { library } = this.props;
+    const currentBlockValid = !!library.blockTypes.filter((type) => type.block_type === this.state.newBlockType).length;
+    if (library.blockTypes.length && !currentBlockValid) {
+      this.setState({ newBlockType: library.blockTypes[0].block_type });
     }
   }
 

--- a/src/library-authoring/library-detail/data/api.js
+++ b/src/library-authoring/library-detail/data/api.js
@@ -1,8 +1,6 @@
 import { ensureConfig, getConfig } from '@edx/frontend-platform';
 import { getAuthenticatedHttpClient } from '@edx/frontend-platform/auth';
 
-import { LIBRARY_TYPES } from '../../common';
-
 ensureConfig(['STUDIO_BASE_URL'], 'library API service');
 
 export async function getLibraryDetail(libraryId) {
@@ -23,7 +21,6 @@ export async function getLibraryDetail(libraryId) {
     ...detailResponse.data,
     blocks: blockResponse.data,
     blockTypes: blockTypeResponse.data,
-    type: LIBRARY_TYPES.COMPLEX,
   };
 
   return library;

--- a/src/library-authoring/list-libraries/LibraryListPage.jsx
+++ b/src/library-authoring/list-libraries/LibraryListPage.jsx
@@ -8,7 +8,9 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faPlus, faSearch } from '@fortawesome/free-solid-svg-icons';
 
 import { LoadingPage } from '../../generic';
-import { LOADING_STATUS, LibraryIndexTabs, libraryShape } from '../common';
+import {
+  LOADING_STATUS, LibraryIndexTabs, libraryShape, LIBRARY_TYPES,
+} from '../common';
 import { LibraryCreateForm } from '../create-library';
 import {
   fetchLibraryList,
@@ -67,6 +69,16 @@ class LibraryListPage extends React.Component {
     });
   }
 
+  handleFilterTypeChange = (event) => {
+    this.handleFilterChange(event);
+    this.props.fetchLibraryList({
+      params: {
+        ...this.state.filterParams,
+        type: event.target.value,
+      },
+    });
+  }
+
   handleFilterSubmit = (event) => {
     event.preventDefault();
     this.props.fetchLibraryList({ params: this.state.filterParams });
@@ -107,6 +119,14 @@ class LibraryListPage extends React.Component {
         })),
       },
     ];
+
+    const typeOptions = [{
+      label: intl.formatMessage(messages['library.list.filter.options.type.types']),
+      group: Object.values(LIBRARY_TYPES).map((value) => (
+        { value, label: intl.formatMessage(messages[`library.list.filter.options.type.${value}`]) }
+      )),
+    }];
+    typeOptions.unshift({ value: '', label: intl.formatMessage(messages['library.list.filter.options.type.all']) });
 
     return (
       <div className="library-list-wrapper">
@@ -193,6 +213,20 @@ class LibraryListPage extends React.Component {
                         options={orgOptions}
                         defaultValue={filterParams ? filterParams.org : null}
                         onChange={this.handleFilterOrgChange}
+                      />
+                    </Form.Group>
+                  </Form.Row>
+                  <Form.Row>
+                    <Form.Group className="w-100">
+                      <Form.Label className="title title-3">
+                        {intl.formatMessage(messages['library.list.filter.options.type.label'])}
+                      </Form.Label>
+                      <Input
+                        name="type"
+                        type="select"
+                        options={typeOptions}
+                        defaultValue={filterParams ? filterParams.type : null}
+                        onChange={this.handleFilterTypeChange}
                       />
                     </Form.Group>
                   </Form.Row>

--- a/src/library-authoring/list-libraries/messages.js
+++ b/src/library-authoring/list-libraries/messages.js
@@ -26,9 +26,19 @@ const messages = defineMessages({
     defaultMessage: 'Type:',
     description: 'Label of the library type metadata item',
   },
+  'library.list.item.type.video': {
+    id: 'library.list.item.type.video',
+    defaultMessage: 'Video (beta)',
+    description: 'Label for the video library type.',
+  },
+  'library.list.item.type.problem': {
+    id: 'library.list.item.type.problem',
+    defaultMessage: 'Problem (beta)',
+    description: 'Label for the problem library type.',
+  },
   'library.list.item.type.complex': {
     id: 'library.list.item.type.complex',
-    defaultMessage: 'Complex',
+    defaultMessage: 'Complex (beta)',
     description: 'Label for the complex library type.',
   },
   'library.list.item.type.legacy': {
@@ -70,6 +80,41 @@ const messages = defineMessages({
     id: 'library.list.filter.options.org.organizations',
     defaultMessage: 'Organizations',
     description: 'Label for the main organization option group.',
+  },
+  'library.list.filter.options.type.label': {
+    id: 'library.list.filter.options.type.label',
+    defaultMessage: 'Type',
+    description: 'Label for the type form group.',
+  },
+  'library.list.filter.options.type.all': {
+    id: 'library.list.filter.options.type.all',
+    defaultMessage: 'All',
+    description: 'Label for the empty type option.',
+  },
+  'library.list.filter.options.type.types': {
+    id: 'library.list.filter.options.type.types',
+    defaultMessage: 'Types',
+    description: 'Label for the main type option group.',
+  },
+  'library.list.filter.options.type.legacy': {
+    id: 'library.list.filter.options.type.legacy',
+    defaultMessage: 'Legacy',
+    description: 'Label for the legacy type option.',
+  },
+  'library.list.filter.options.type.complex': {
+    id: 'library.list.filter.options.type.complex',
+    defaultMessage: 'Complex (beta)',
+    description: 'Label for the complex type option.',
+  },
+  'library.list.filter.options.type.video': {
+    id: 'library.list.filter.options.type.video',
+    defaultMessage: 'Video (beta)',
+    description: 'Label for the video type option.',
+  },
+  'library.list.filter.options.type.problem': {
+    id: 'library.list.filter.options.type.problem',
+    defaultMessage: 'Problem (beta)',
+    description: 'Label for the video type option.',
   },
   'library.list.aside.title': {
     id: 'library.list.aside.title',

--- a/src/library-authoring/studio-header/StudioHeader.jsx
+++ b/src/library-authoring/studio-header/StudioHeader.jsx
@@ -50,6 +50,7 @@ const StudioHeader = ({ intl, library }) => {
                     </Dropdown.Toggle>
                     <Dropdown.Menu className="p-4 mt-1 fade">
                       <Dropdown.Item className="p-0" as={Link} to={ROUTES.Detail.EDIT_SLUG(library.id)}>{intl.formatMessage(messages['library.header.settings.details'])}</Dropdown.Item>
+                      <Dropdown.Item className="p-0" as={Link} to={ROUTES.Detail.ACCESS_SLUG(library.id)}>{intl.formatMessage(messages['library.header.settings.access'])}</Dropdown.Item>
                     </Dropdown.Menu>
                   </Dropdown>
                 </nav>

--- a/src/library-authoring/studio-header/messages.js
+++ b/src/library-authoring/studio-header/messages.js
@@ -16,6 +16,11 @@ const messages = defineMessages({
     defaultMessage: 'Details',
     description: 'Text for the details item in the settings menu.',
   },
+  'library.header.settings.access': {
+    id: 'library.header.settings.access',
+    defaultMessage: 'User Access',
+    description: 'Text for the user access permissions item in the settings menu.',
+  },
   'library.header.nav.help.title': {
     id: 'library.header.nav.help.title',
     defaultMessage: 'Online Help',

--- a/src/setupTest.js
+++ b/src/setupTest.js
@@ -1,8 +1,11 @@
 /* eslint-disable import/no-extraneous-dependencies */
 import 'babel-polyfill';
+import MutationObserver from '@sheerun/mutationobserver-shim';
 import { mergeConfig } from '@edx/frontend-platform';
 
 mergeConfig({
   STUDIO_BASE_URL: process.env.STUDIO_BASE_URL,
   BLOCKSTORE_COLLECTION_UUID: process.env.BLOCKSTORE_COLLECTION_UUID,
 });
+
+window.MutationObserver = MutationObserver;

--- a/src/store.js
+++ b/src/store.js
@@ -10,6 +10,8 @@ import {
   libraryCreateStoreName,
   libraryListReducer,
   libraryListStoreName,
+  libraryAccessStoreName,
+  libraryAccessReducer,
 } from './library-authoring';
 
 const store = configureStore({
@@ -19,6 +21,7 @@ const store = configureStore({
     [libraryEditStoreName]: libraryEditReducer,
     [libraryCreateStoreName]: libraryCreateReducer,
     [libraryListStoreName]: libraryListReducer,
+    [libraryAccessStoreName]: libraryAccessReducer,
   },
 });
 

--- a/src/vendor/studio.scss
+++ b/src/vendor/studio.scss
@@ -319,6 +319,22 @@ $tmg-f3: 0.125s;
 $f-sans-serif: 'Open Sans','Helvetica Neue', Helvetica, Arial, sans-serif;
 $white: rgb(255, 255, 255) !default;
 $white-t3: rgba($white, 0.75) !default;
+$yellow: rgb(237, 189, 60) !default;
+$yellow-l1: tint($yellow, 20%) !default;
+$yellow-l2: tint($yellow, 40%) !default;
+$yellow-l3: tint($yellow, 60%) !default;
+$yellow-l4: tint($yellow, 80%) !default;
+$yellow-l5: tint($yellow, 90%) !default;
+$yellow-d1: shade($yellow, 20%) !default;
+$yellow-d2: shade($yellow, 40%) !default;
+$yellow-d3: shade($yellow, 60%) !default;
+$yellow-d4: shade($yellow, 80%) !default;
+$yellow-s1: saturate($yellow, 15%) !default;
+$yellow-s2: saturate($yellow, 30%) !default;
+$yellow-s3: saturate($yellow, 45%) !default;
+$yellow-u1: desaturate($yellow, 15%) !default;
+$yellow-u2: desaturate($yellow, 30%) !default;
+$yellow-u3: desaturate($yellow, 45%) !default;
 
 // Imported from:
 // edx-platform/common/cms/static/sass/bootstrap/_mixins.scss


### PR DESCRIPTION
This pull request creates an initial set of unit tests and helper functions that were created in the process of creating them, as well as a handful of improvements that were found while testing.

**Dependencies**: https://github.com/edx/frontend-app-library-authoring/pull/9

**Merge deadline**: This PR not to be merged. It is the review copy for https://github.com/edx/frontend-app-library-authoring/pull/10

**Testing instructions**:

1. `npm install`
2. `npm run test`

**Author notes and concerns**:

This PR includes several functions that I believe will help make the tests more succinct. They're a little metaprogrammy but they make me happy. It also includes a set of factory functions that I hope will serve as a useful pattern to build from.

The tests are built for the Library Access section of the app because it is the one I've built and it uses the [container pattern](https://www.freecodecamp.org/news/react-superpowers-container-pattern-20d664bdae65/), which I anticipated would make it fairly easy to test. So far, so good.

Because there is another PR for tests that is being worked on by @arbrandes during our current sprint at OpenCraft, I've elected to go ahead and put up this Pull Request before our second week begins in order that the infrastructure functions might be used for making more unit tests more effectively. The Library Access PR, thus, is not fully covered, but it can be with a follow-up PR later if desired.

**Reviewers**
- [x] @mavidser
- [ ] @kdmccormick 
